### PR TITLE
Ensure markdup report for phix does not clash with main markdup report

### DIFF
--- a/data/tophat2_sample_template.vtf
+++ b/data/tophat2_sample_template.vtf
@@ -684,7 +684,7 @@
 	{
 		"id":"bammarkduplicates_phix",
 		"type":"EXEC",
-		"cmd":"bammarkduplicates M=markdups_metrics.txt level=0"
+		"cmd":"bammarkduplicates M=phix_markdups_metrics.txt level=0"
 	},
 	{
 		"id":"bamrecompress_phix",


### PR DESCRIPTION
quick fix - this should be replaced by parameterising and use fo "rpt"
