### PR TITLE
removed the incorrect "level=0" and sortorder flag from the final bamrecompress

### DIFF
--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -151,7 +151,6 @@
 			"subst_constructor":{
 				"vals":[
 					"bamrecompress",
-					"SO=coordinate",
 					"verbose=0",
 					"index=1",
 					{"subst_param_name":"br_indexfile_flag",


### PR DESCRIPTION
Removed the incorrect level specification from the final bamrecompress command, reverting to default as in current production templates
