### PR TITLE
allow specification of markduplicates executable as parameter

### DIFF
--- a/data/bwamem_wtsi_stage2_template.vtf
+++ b/data/bwamem_wtsi_stage2_template.vtf
@@ -556,8 +556,8 @@
 			"required":"yes",
 			"subst_constructor":{
 				"vals":[
-					"bamstreamingmarkduplicates ",
-					"level=0 ",
+					{"subst_param_name":"bmd_cmd","required":"no","default":"bammarkduplicates2"},
+					" level=0 ",
 					"verbose=0 ",
 					"M=",
 					{"subst_param_name":"outdatadir","required":"no","default":"."},
@@ -627,8 +627,8 @@
 			"required":"yes",
 			"subst_constructor":{
 				"vals":[
-					"bamstreamingmarkduplicates ",
-					"level=0 ",
+					{"subst_param_name":"bmd_cmd","required":"no","default":"bammarkduplicates2"},
+					" level=0 ",
 					"verbose=0 ",
 					"M=",
 					{"subst_param_name":"outdatadir","required":"no","default":"."},

--- a/data/tophat2_wtsi_stage2_template.vtf
+++ b/data/tophat2_wtsi_stage2_template.vtf
@@ -792,8 +792,8 @@
 			"required":"yes",
 			"subst_constructor":{
 				"vals":[
-					"bamstreamingmarkduplicates ",
-					"level=0 ",
+					{"subst_param_name":"bmd_cmd","required":"no","default":"bammarkduplicates2"},
+					" level=0 ",
 					"M=",
 					{"subst_param_name":"outdatadir","required":"no","default":"."},
 					"/",
@@ -862,8 +862,8 @@
 			"required":"yes",
 			"subst_constructor":{
 				"vals":[
-					"bamstreamingmarkduplicates ",
-					"level=0 ",
+					{"subst_param_name":"bmd_cmd","required":"no","default":"bammarkduplicates2"},
+					" level=0 ",
 					"M=",
 					{"subst_param_name":"outdatadir","required":"no","default":"."},
 					"/",


### PR DESCRIPTION
allow specification of (biobambam) markduplicates executable as a subst_param, with a default of bammarkduplicates2 until questions about bammarkstreamingduplicates are resolved
