### PR TITLE
fix extra hash type flag (bamseqchksum)

### DIFF
--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -168,7 +168,7 @@
 				"hash",
 				{"subst":"seqchksum_hash_type"}
 			],
-			"postproc":{"op":"pack","pad":"="}
+			"postproc":{"op":"concat","pad":"="}
 		}
 	},
 	{


### PR DESCRIPTION
Corrected mistaken use of "pack" instead of "concat" for the parameter which specified an additional alternative hash (sha512primesums512) for bamseqchksum. This caused the creation of a seqchksum file with the sha512primesums512 name but with default hash contents..