### PR TITLE
Vtfp fixes

### DIFF
--- a/bin/vtfp.pl
+++ b/bin/vtfp.pl
@@ -71,6 +71,9 @@ if($outname) { open $out, ">$outname" or croak "Failed to open $outname for outp
 if($template_path) {
 	$template_path = [ (split q[:], $template_path) ];
 }
+else {
+	$template_path = [];
+}
 
 my $param_store;
 my $globals = { node_prefixes => { auto_node_prefix => 0, used_prefixes => {}}, vt_file_stack => [], processed_sp_files => {}, template_path => $template_path, };

--- a/bin/vtfp.pl
+++ b/bin/vtfp.pl
@@ -448,7 +448,7 @@ sub fetch_subst_value {
 	}
 
 	if(not defined $param_store->[0]->{varnames}->{$param_name}) {	# create a "writeable" param_store entry at local level
-		my $new_param_entry = (not defined $param_entry)? { name => $param_name, }: dclone $param_entry;
+		my $new_param_entry = (not defined $param_entry)? { name => $param_name, _declared_by => [], }: dclone $param_entry;
 
 		$param_store->[0]->{varnames}->{$param_name} = $new_param_entry; # adding to the "local" variable store
 

--- a/bin/vtfp.pl
+++ b/bin/vtfp.pl
@@ -387,7 +387,6 @@ sub subst_walk {
 					$logger->($VLFATAL, q[value for a subst directive must be a param name (not a reference), index for subst is: ], $i);
 				}
 
-#				$elem->[$i] = fetch_subst_value($param_name, $param_store, $subst_requests);
 				my $sval = fetch_subst_value($param_name, $param_store, $subst_requests);
 				if(ref $sval eq q[ARRAY]) {
 					splice @$elem, $i, 1, @$sval;

--- a/data/vtlib/README.vtlib
+++ b/data/vtlib/README.vtlib
@@ -16,7 +16,7 @@ $ vtfp.pl -l aln_vtf.log -o aln.json \
 -keys aligner_numthreads -vals <NUMBER_OF_THREADS_USED_BY_ALIGNER> \
 cfgdata/wtsi_alignment_stage2_template.json 
 
-$ viv.pl -x -s -o v 3 -o viv_run.log aln.json
+$ viv.pl -x -s -v 3 -o viv_run.log aln.json
 
 * vtfp.pl flags (subst_params) description:
  indatadir - input data, default to '.'
@@ -43,5 +43,6 @@ $ vtfp.pl -l aws2_bwa_mem.vtf.log -o aws2_bwa_mem.json -keys indatadir -vals ind
 tophat2:
 $ vtfp.pl -l aws2_tophat2.vtf.log -o aws2_tophat2.json -keys indatadir -vals indata -keys outdatadir -vals outdata_tophat2 -keys cfgdatadir -vals cfgdata -keys tmpdir -vals tmpdata -keys rpt -vals 13430_8#1 -keys alignment_method -vals tophat2 -keys reposdir -vals /path/to/references -keys alignment_reference_genome_name -vals Homo_sapiens/1000Genomes_hs37d5/all/bowtie2/hs37d5.fa -keys reference_dict_name -vals Homo_sapiens/1000Genomes_hs37d5/all/picard/hs37d5.fa.dict -keys reference_genome_fasta_name -vals Homo_sapiens/1000Genomes_hs37d5/all/fasta/hs37d5.fa -keys phix_reference_genome_fasta_name -vals PhiX/default/all/fasta/phix_unsnipped_short_no_N.fa -keys aligner_numthreads -vals 8 cfgdata/alignment_wtsi_stage2_template.json
 
-
+tophat2 with ysplit:
+$ vtfp.pl -l aws2_tophat2_ysplit.vtf.log -o aws2_tophat2_ysplit.json -keys indatadir -vals indata -keys outdatadir -vals outdata_tophat2_ysplit -keys cfgdatadir -vals cfgdata -keys tmpdir -vals tmpdata -keys rpt -vals 13430_8#1 -keys alignment_method -vals tophat2 -keys reposdir -vals /path/to/reference_repository -keys alignment_reference_genome_name -vals references/Homo_sapiens/1000Genomes_hs37d5/all/bowtie2/hs37d5.fa -keys reference_dict_name -vals references/Homo_sapiens/1000Genomes_hs37d5/all/picard/hs37d5.fa.dict -keys reference_genome_fasta_name -vals references/Homo_sapiens/1000Genomes_hs37d5/all/fasta/hs37d5.fa -keys phix_reference_genome_fasta_name -vals references/PhiX/default/all/fasta/phix_unsnipped_short_no_N.fa -keys transcriptome_subpath -vals transcriptomes/Homo_sapiens/ensembl_75_transcriptome/1000Genomes_hs37d5/tophat2/1000Genomes_hs37d5.known -keys aligner_numthreads -vals 8 -keys library_type -vals fr-firststrand -keys final_output_prep_target_name -vals split_by_chromosome -keys split_bam_by_chromosome_flags -vals S=Y -keys split_bam_by_chromosome_flags -vals V=true -keys split_indicator -vals _yhuman cfgdata/alignment_wtsi_stage2_template.json
 

--- a/data/vtlib/bwa_mem_alignment.json
+++ b/data/vtlib/bwa_mem_alignment.json
@@ -20,17 +20,18 @@
                 "required": "no",
                 "comment":"this will expand to a set of subst_param elements"
         },
-	{"id":"bwa_T_value","required":"no","default":"0"},
+	{"id":"bwa_mem_T_value","required":"no","default":"0"},
 	{
-		"id":"bwa_T_flag",
+		"id":"bwa_mem_T_flag",
 		"required":"no",
 		"subst_constructor":{
 			"vals":[
 				"-T",
-				{"subst":"bwa_T_value"}
+				{"subst":"bwa_mem_T_value"}
 			]
 		}
 	},
+	{"id":"bwa_mem_p_flag","required":"no","default":"-p","comment":"by default, paired alignment is assumed"},
 	{
 		"id":"bwa_mem_cmd",
 		"required":"yes",
@@ -40,8 +41,8 @@
 				"mem",
 				"-t",
 				{"subst":"aligner_numthreads"},
-				"-p",
-				{"subst":"bwa_T_flag"}
+				{"subst":"bwa_mem_p_flag"},
+				{"subst":"bwa_mem_T_flag"}
 			],
 			"postproc":{"op":"pack","pad":" "}
 		}


### PR DESCRIPTION
vtfp.pl:
  added nullkeys functionality and flag to vtfp.pl
  corrected an instance of parameter_store entry creation which lacked the _declared_by attribute
  add validation check for names of VTFILE and SPFILE nodes
  default template_path to empty list instead of undef (mainly to fix error reporting message)

bwa_mem_alignment.json:
  changed bwa mem -p flag to a parameter (so it is possible to switch it off and do single-end alignment)
  renamed bwa_T_flag to bwa_mem_T_flag

update README.vtlib to gve example of ysplit, and correct flags in viv.pl example


