### PR TITLE
add new teepot node to final_output_prep

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 CHANGES LOG
 -----------
 
+ - add tee after seqchksum (bam) output to split output to file and cmp node, to remove deadlock
+ - remove -s flag from all cmp commands (improve diagnostics)
+
 release 0.16.2
  - remove superfluous "-" argumant to bamseqchksum command
  - increase teepot timeout for bmd_multiway node to 50000 (from 500)

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -562,7 +562,7 @@
 		"type":"EXEC",
 		"use_STDIN": false,
 		"use_STDOUT": true,
-		"cmd":["cmp", "-s", "__BAM_SEQCHKSUM_IN__", "__CRAM_SEQCHKSUM_IN__"]
+		"cmd":["cmp", "__BAM_SEQCHKSUM_IN__", "__CRAM_SEQCHKSUM_IN__"]
 	}
 ],
 "edges":[

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -503,6 +503,14 @@
 		"cmd":{"subst":"seqchksum_cmd"}
 	},
 	{
+		"id":"seqchksum_tee",
+		"type":"EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": false,
+		"cmd":["teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__SEQCHKSUM_OUT__" ],
+		"comment":"allow a generous 500 minutes for the teepot timeout; specify parameter value teepot_tempdir_value to specify teepot tempdir"
+	},
+	{
 		"id":"seqchksum_extrahash",
 		"type":"EXEC",
 		"use_STDIN": true,
@@ -579,12 +587,13 @@
         { "id":"tee_to_cram", "from":"scramble_tee:__CRAM_OUT__", "to":"cram_file" },
         { "id":"corrected_md5_out", "from":"postprocess_md5", "to":"cram_md5" },
         { "id":"bamcheck_to_file", "from":"bamcheck", "to":"bamcheck_file" },
-	{ "id":"scs_to_file", "from":"seqchksum", "to":"seqchksum_file" },
+	{ "id":"scs_to_tee", "from":"seqchksum", "to":"seqchksum_tee" },
+	{ "id":"scs_tee_to_file", "from":"seqchksum_tee:__FILE_OUT__", "to":"seqchksum_file" },
+	{ "id":"scs_tee_to_cmp", "from":"seqchksum_tee:__SEQCHKSUM_OUT__", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" },
 	{ "id":"scs_extrahash_to_file", "from":"seqchksum_extrahash", "to":"seqchksum_extrahash_file" },
         { "id":"samtools_stats_F0x900_to_file", "from":"samtools_stats_F0x900", "to":"stats_F0x900_file" },
         { "id":"samtools_stats_F0xB00_to_file", "from":"samtools_stats_F0xB00", "to":"stats_F0xB00_file" },
         { "id":"flagstat_to_file", "from":"flagstat", "to":"flagstat_file" },
-        { "id":"cscs_to_cmp", "from":"cram_seqchksum", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" },
-        { "id":"bscs_to_cmp", "from":"seqchksum_file", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" }
+        { "id":"cscs_to_cmp", "from":"cram_seqchksum", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }
 ]
 }

--- a/data/vtlib/seqchksum.json
+++ b/data/vtlib/seqchksum.json
@@ -57,7 +57,7 @@
                 "type":"EXEC",
 		"use_STDIN": false,
 		"use_STDOUT": false,
-                "cmd":"cmp -s __INPUTCHK_IN__ __OUTPUTCHK_IN__",
+                "cmd":"cmp __INPUTCHK_IN__ __OUTPUTCHK_IN__",
                 "description":"check input primary/sequence data matches output"
         }
 ],

--- a/data/vtlib/seqchksum_hs.json
+++ b/data/vtlib/seqchksum_hs.json
@@ -58,7 +58,7 @@
                 "type":"EXEC",
 		"use_STDIN": false,
 		"use_STDOUT": false,
-                "cmd":"cmp -s __INPUTCHK_IN__ __OUTPUTCHK_IN__",
+                "cmd":"cmp __INPUTCHK_IN__ __OUTPUTCHK_IN__",
                 "description":"check input primary/sequence data matches output"
         }
 ],

--- a/data/vtlib/seqchksum_realign.json
+++ b/data/vtlib/seqchksum_realign.json
@@ -22,7 +22,7 @@
                 "type":"EXEC",
 		"use_STDIN": false,
 		"use_STDOUT": false,
-                "cmd":"cmp -s __INPUTCHK__ __OUTPUTCHK__",
+                "cmd":"cmp __INPUTCHK__ __OUTPUTCHK__",
                 "description":"check input primary/sequence data matches output"
         }
 ],


### PR DESCRIPTION
add new teepot node after seqchksum (bam) output to split output to file and cmp node, to remove deadlock
