### PR TITLE
Seqchksum tee add output

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 CHANGES LOG
 -----------
 
+ - add extra branch to teepot command in to stream seqchksum output downstream (instead of using a file as an internal node)
+
 release 0.16.3
  - add tee after seqchksum (bam) output to split output to file and cmp node, to remove deadlock
  - remove -s flag from all cmp commands (improve diagnostics)

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -7,7 +7,7 @@
 			"_stdin_":"bamsort_coord"
 		},
 		"outputs":{
-			"_stdout_":"seqchksum_file"
+			"_stdout_":"seqchksum_tee:__FINAL_OUT__"
 		}
 	}
 },
@@ -507,7 +507,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": false,
-		"cmd":["teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__SEQCHKSUM_OUT__" ],
+		"cmd":["teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__SEQCHKSUM_OUT__", "__FINAL_OUT__" ],
 		"comment":"allow a generous 500 minutes for the teepot timeout; specify parameter value teepot_tempdir_value to specify teepot tempdir"
 	},
 	{


### PR DESCRIPTION
final_output_prep template now streams its seqchksum output instead of using a file