### PR TITLE
 add bamseqchksum RAFILE for cram and change seqchksum_file from OUTF…

### DIFF
--- a/data/vtlib/final_output_noalign_prep.json
+++ b/data/vtlib/final_output_noalign_prep.json
@@ -115,6 +115,15 @@
 		}
 	},
 	{
+		"id":"seqchksum_file_cram",
+		"required":"yes",
+		"subst_constructor":{
+			"vals":[ {"subst":"tmpdir"}, "/", {"subst":"fopid"}, ".cram.seqchksum" ],
+			"postproc":{"op":"concat", "pad":""}
+		},
+		"comment":"this temporary file is used for removing blocking problems at cmp_seqchksum"
+	},
+	{
 		"id":"seqchksum_extrahash_file",
 		"required":"yes",
 		"subst_constructor":{
@@ -241,7 +250,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": false,
-		"cmd":[ "teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__SEQCHKSUM_OUT__", "__FINAL_OUT__" ],
+		"cmd":[ "teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__FINAL_OUT__" ],
 		"comment":"allow a generous 500 minutes for the teepot timeout; specify parameter value teepot_tempdir_value to specify teepot tempdir"
 	},
 	{
@@ -264,6 +273,7 @@
 	{ "id":"cram_file", "type":"OUTFILE", "name":{"subst":"cram_file"} },
 	{ "id":"cram_md5", "type":"OUTFILE", "name":{"subst":"cram_md5"} },
 	{ "id":"seqchksum_file", "type":"OUTFILE", "name":{"subst":"seqchksum_file"} },
+	{ "id":"seqchksum_file_cram", "type":"RAFILE", "name":{"subst":"seqchksum_file_cram"}, "comment":"this file is a temporary fix for blocking problems at the cmp_seqchksum node" },
 	{ "id":"seqchksum_extrahash_file", "type":"OUTFILE", "name":{"subst":"seqchksum_extrahash_file"} },
 	{ "id":"bamcheck_file", "type":"OUTFILE", "name":{"subst":"bamcheck_file"} },
 	{ "id":"stats_F0x900_file", "type":"OUTFILE", "name":{"subst":"stats_F0x900_file"} },
@@ -313,11 +323,12 @@
         { "id":"bamcheck_to_file", "from":"bamcheck", "to":"bamcheck_file" },
 	{ "id":"scs_to_tee", "from":"seqchksum", "to":"seqchksum_tee" },
 	{ "id":"scs_tee_to_file", "from":"seqchksum_tee:__FILE_OUT__", "to":"seqchksum_file" },
-	{ "id":"scs_tee_to_cmp", "from":"seqchksum_tee:__SEQCHKSUM_OUT__", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" },
+	{ "id":"scs_file_to_cmp", "from":"seqchksum_file", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" },
 	{ "id":"scs_extrahash_to_file", "from":"seqchksum_extrahash", "to":"seqchksum_extrahash_file" },
         { "id":"samtools_stats_F0x900_to_file", "from":"samtools_stats_F0x900", "to":"stats_F0x900_file" },
         { "id":"samtools_stats_F0xB00_to_file", "from":"samtools_stats_F0xB00", "to":"stats_F0xB00_file" },
         { "id":"flagstat_to_file", "from":"flagstat", "to":"flagstat_file" },
-        { "id":"cscs_to_cmp", "from":"cram_seqchksum", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }
+	{ "id":"cscs_to_file", "from":"cram_seqchksum", "to":"seqchksum_file_cram" },
+	{ "id":"cscs_file_to_cmp", "from":"seqchksum_file_cram", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }
 ]
 }

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -149,6 +149,15 @@
 		}
 	},
 	{
+		"id":"seqchksum_file_cram",
+		"required":"yes",
+		"subst_constructor":{
+			"vals":[ {"subst":"tmpdir"}, "/", {"subst":"fopid"}, ".cram.seqchksum" ],
+			"postproc":{"op":"concat", "pad":""}
+		},
+		"comment":"this temporary file is used for removing blocking problems at cmp_seqchksum"
+	},
+	{
 		"id":"seqchksum_extrahash_file",
 		"required":"yes",
 		"subst_constructor":{
@@ -289,7 +298,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": false,
-		"cmd":[ "teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__SEQCHKSUM_OUT__", "__FINAL_OUT__" ],
+		"cmd":[ "teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__FINAL_OUT__" ],
 		"comment":"allow a generous 500 minutes for the teepot timeout; specify parameter value teepot_tempdir_value to specify teepot tempdir"
 	},
 	{
@@ -319,6 +328,7 @@
 	{ "id":"cram_file", "type":"OUTFILE", "name":{"subst":"cram_file"} },
 	{ "id":"cram_md5", "type":"OUTFILE", "name":{"subst":"cram_md5"} },
 	{ "id":"seqchksum_file", "type":"OUTFILE", "name":{"subst":"seqchksum_file"} },
+	{ "id":"seqchksum_file_cram", "type":"RAFILE", "name":{"subst":"seqchksum_file_cram"}, "comment":"this file is a temporary fix for blocking problems at the cmp_seqchksum node" },
 	{ "id":"seqchksum_extrahash_file", "type":"OUTFILE", "name":{"subst":"seqchksum_extrahash_file"} },
 	{ "id":"bamcheck_file", "type":"OUTFILE", "name":{"subst":"bamcheck_file"} },
 	{ "id":"stats_F0x900_file", "type":"OUTFILE", "name":{"subst":"stats_F0x900_file"} },
@@ -371,11 +381,12 @@
         { "id":"bamcheck_to_file", "from":"bamcheck", "to":"bamcheck_file" },
 	{ "id":"scs_to_tee", "from":"seqchksum", "to":"seqchksum_tee" },
 	{ "id":"scs_tee_to_file", "from":"seqchksum_tee:__FILE_OUT__", "to":"seqchksum_file" },
-	{ "id":"scs_tee_to_cmp", "from":"seqchksum_tee:__SEQCHKSUM_OUT__", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" },
+	{ "id":"scs_file_to_cmp", "from":"seqchksum_file", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" },
 	{ "id":"scs_extrahash_to_file", "from":"seqchksum_extrahash", "to":"seqchksum_extrahash_file" },
         { "id":"samtools_stats_F0x900_to_file", "from":"samtools_stats_F0x900", "to":"stats_F0x900_file" },
         { "id":"samtools_stats_F0xB00_to_file", "from":"samtools_stats_F0xB00", "to":"stats_F0xB00_file" },
         { "id":"flagstat_to_file", "from":"flagstat", "to":"flagstat_file" },
-        { "id":"cscs_to_cmp", "from":"cram_seqchksum", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }
+        { "id":"cscs_to_file", "from":"cram_seqchksum", "to":"seqchksum_file_cram" },
+        { "id":"cscsfile_to_cmp", "from":"seqchksum_file_cram", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }
 ]
 }

--- a/data/vtlib/merge_final_output_prep.json
+++ b/data/vtlib/merge_final_output_prep.json
@@ -139,6 +139,15 @@
 		}
 	},
 	{
+		"id":"seqchksum_file_cram",
+		"required":"yes",
+		"subst_constructor":{
+                        "vals":[ {"subst":"tmpdir"}, "/", {"subst":"library"}, ".cram.seqchksum" ],
+			"postproc":{"op":"concat", "pad":""}
+		},
+		"comment":"this temporary file is used for removing blocking problems at cmp_seqchksum"
+	},
+	{
 		"id":"seqchksum_extrahash_file",
 		"required":"yes",
 		"subst_constructor":{
@@ -274,7 +283,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": false,
-		"cmd":[ "teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__SEQCHKSUM_OUT__", "__FINAL_OUT__" ],
+		"cmd":[ "teepot", "-v", {"subst":"teepot_tempdir_flag"}, "-w", "30000", "__FILE_OUT__", "__FINAL_OUT__" ],
 		"comment":"allow a generous 500 minutes for the teepot timeout; specify parameter value teepot_tempdir_value to specify teepot tempdir"
 	},
 	{
@@ -289,6 +298,7 @@
 	{ "id":"cram_file", "type":"OUTFILE", "name":{"subst":"cram_file"} },
 	{ "id":"cram_md5", "type":"OUTFILE", "name":{"subst":"cram_md5"} },
 	{ "id":"seqchksum_file", "type":"OUTFILE", "name":{"subst":"seqchksum_file"} },
+	{ "id":"seqchksum_file_cram", "type":"RAFILE", "name":{"subst":"seqchksum_file_cram"}, "comment":"this file is a temporary fix for blocking problems at the cmp_seqchksum node" },
 	{ "id":"seqchksum_extrahash_file", "type":"OUTFILE", "name":{"subst":"seqchksum_extrahash_file"} },
 	{ "id":"bamcheck_file", "type":"OUTFILE", "name":{"subst":"bamcheck_file"} },
 	{ "id":"stats_F0x900_file", "type":"OUTFILE", "name":{"subst":"stats_F0x900_file"} },
@@ -338,11 +348,12 @@
         { "id":"bamcheck_to_file", "from":"bamcheck", "to":"bamcheck_file" },
 	{ "id":"scs_to_tee", "from":"seqchksum", "to":"seqchksum_tee" },
 	{ "id":"scs_tee_to_file", "from":"seqchksum_tee:__FILE_OUT__", "to":"seqchksum_file" },
-	{ "id":"scs_tee_to_cmp", "from":"seqchksum_tee:__SEQCHKSUM_OUT__", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" },
+	{ "id":"scs_file_to_cmp", "from":"seqchksum_file", "to":"cmp_seqchksum:__BAM_SEQCHKSUM_IN__" },
 	{ "id":"scs_extrahash_to_file", "from":"seqchksum_extrahash", "to":"seqchksum_extrahash_file" },
         { "id":"samtools_stats_F0x900_to_file", "from":"samtools_stats_F0x900", "to":"stats_F0x900_file" },
         { "id":"samtools_stats_F0xB00_to_file", "from":"samtools_stats_F0xB00", "to":"stats_F0xB00_file" },
         { "id":"flagstat_to_file", "from":"flagstat", "to":"flagstat_file" },
-        { "id":"cscs_to_cmp", "from":"cram_seqchksum", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }
+	{ "id":"cscs_to_file", "from":"cram_seqchksum", "to":"seqchksum_file_cram" },
+	{ "id":"cscs_file_to_cmp", "from":"seqchksum_file_cram", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }
 ]
 }


### PR DESCRIPTION

 add bamseqchksum RAFILE for cram and change seqchksum_file from OUTFILE to RAFILE and move it between seqchksum_tee and cmp_seqchksum. This should prevent blocking problems leading to teepot spillage.