### PR TITLE
Fixup by reverting coord sort to bamsort

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 CHANGES LOG
 -----------
 
+ - use threaded bamsormadup in place of name bamsort
  - turn off compression of AlignmentFilter output
- - use threaded bamsormadup in place of bamsort
  - changes to merge_final_output_prep to use tears to stream data into iRODS, generate extra stats,
    use ref in stats file generation and minor tidy up.
 

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -24,13 +24,6 @@
 			"postproc":{"op":"concat", "pad":""}
 		}
 	},
-	{
-		"id":"bsmd_threads",
-		"subst_constructor":{
-			"vals":[ "threads", {"subst":"aligner_numthreads"} ],
-			"postproc":{"op":"concat", "pad":"="}
-		}
-	},
         {
                 "id":"scramble_reference_flag",
                 "required":"no",
@@ -210,7 +203,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd": [ "bamsormadup", {"subst":"bsmd_threads"}, "SO=coordinate", "level=0", "verbose=0", "fixmate=1", "adddupmarksupport=1", {"subst":"bs_tmpfile_flag"} ]
+		"cmd": [ "bamsort", "SO=coordinate", "level=0", "verbose=0", "fixmate=1", "adddupmarksupport=1", {"subst":"bs_tmpfile_flag"} ]
 	},
 	{
 		"id":"bammarkduplicates",


### PR DESCRIPTION
Cope with older versions of Biobambam (seemed to be okay with 2.0.25, not with 2.0.19)

This reverts commit d7ab079ec2715ce4bfa9bc5e361f0de8ecf33819.

Conflicts:

	Changes