### PR TITLE
Splice prune

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 CHANGES LOG
 -----------
 
+- final_output_prep changes to support optional targeted stats files.
+
 release 0.18.0
 - stage1 analysis : update to bcl_phix_deplex_wtsi_stage1_template; addition of new subgraphs
 - added bcftools_genotype_call template for library merge gtcheck qc test

--- a/Changes
+++ b/Changes
@@ -1,7 +1,16 @@
 CHANGES LOG
 -----------
 
-- final_output_prep changes to support optional targeted stats files.
+ - add ability to splice and prune nodes from the final graph
+ - final_output_prep changes to support optional targeted stats files.
+ - use threaded bamsormadup in place of bamsort for coord sort
+
+release 0.18.2
+ - propagate any 'AH' fields provided by the aligner when providing full SQ headers (bwa0.7.15)
+ - fix bamindexdecoder.json template: add pack option to bamindexdecoder_java_cmd array to handle undefined parameters; change default implementation from "samtools decode" to java BamIndexDecoder
+
+release 0.18.1
+- corrected typo (add_item instead of additem) which can cause compilation failure
 
 release 0.18.0
 - stage1 analysis : update to bcl_phix_deplex_wtsi_stage1_template; addition of new subgraphs

--- a/bin/vtfp.pl
+++ b/bin/vtfp.pl
@@ -484,7 +484,7 @@ sub subst_walk {
 	elsif(ref $elem eq q[JSON::XS::Boolean]) {
 	}
 	else {
-		$ewi->{add_item}->($EWI_WARNING, 2, "REF TYPE $r currently not processable");
+		$ewi->{additem}->($EWI_WARNING, 2, "REF TYPE $r currently not processable");
 	}
 
 	return;

--- a/data/vtlib/alignment_wtsi_stage2_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_template.json
@@ -244,9 +244,9 @@
 				"MAX_RECORDS_IN_RAM=500000",
 				"CREATE_INDEX=false",
 				"IN=__PHIX_BAM_IN__",
-				"IN=__TARGET_BAM_IN__",
+				{"subst":"af_target_in_flag","ifnull":"IN=__TARGET_BAM_IN__"},
 				"OUT=__PHIX_BAM_OUT__",
-				"OUT=/dev/stdout",
+				{"subst":"af_target_out_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ {"subst":"af_target_out_flag_name", "ifnull":{"subst":"OUT"}}, "/dev/stdout" ],"postproc":{"op":"concat","pad":"="}}}},
 				"METRICS_FILE=__AF_METRICS_OUT__"
 		]
 	},

--- a/data/vtlib/alignment_wtsi_stage2_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_template.json
@@ -246,7 +246,7 @@
 				"IN=__PHIX_BAM_IN__",
 				{"subst":"af_target_in_flag","ifnull":"IN=__TARGET_BAM_IN__"},
 				"OUT=__PHIX_BAM_OUT__",
-				{"subst":"af_target_out_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ {"subst":"af_target_out_flag_name", "ifnull":{"subst":"OUT"}}, "/dev/stdout" ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"af_target_out_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ {"subst":"af_target_out_flag_name", "ifnull":"OUT"}, "/dev/stdout" ],"postproc":{"op":"concat","pad":"="}}}},
 				"METRICS_FILE=__AF_METRICS_OUT__"
 		]
 	},

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -64,7 +64,8 @@
 	{"id":"stats_filter__F0x900","required":"no","default":"0x900"},
 	{"id":"stats_filter__F0xB00","required":"no","default":"0xB00"},
 	{"id":"bam_stats_executable","required":"no","default":"bam_stats"},
-	{"id":"calibration_pu_executable","required":"no","default":"calibration_pu"},
+        {"id":"bait_regions_file","required":"yes","comment":"regions file for optional bait stats"},
+        {"id":"calibration_pu_executable","required":"no","default":"calibration_pu"},
 	{"id":"calibration_pu_bad_tiles_count","required":"no","default":"2"},
 	{
 		"id":"calibration_pu_prefix",
@@ -187,6 +188,20 @@
 		}
 	},
 	{
+		"id":"stats_F0x900_bait_file",
+		"subst_constructor":{
+			"vals":[ {"subst":"outdatadir"}, "/", {"subst":"fopid"}, "_F0x900_bait.stats" ],
+			"postproc":{"op":"concat", "pad":""}
+		}
+	},
+	{
+		"id":"stats_F0xB00_bait_file",
+		"subst_constructor":{
+			"vals":[ {"subst":"outdatadir"}, "/", {"subst":"fopid"}, "_F0xB00_bait.stats" ],
+			"postproc":{"op":"concat", "pad":""}
+		}
+	},
+	{
 		"id":"bam_stats_file",
 		"required":"yes",
 		"subst_constructor":{
@@ -233,7 +248,7 @@
 		"use_STDIN": true,
 		"use_STDOUT": false,
 		"comment":"specify parameter value teepot_tempdir_value to specify teepot tempdir",
-		"cmd":[ "teepot", {"subst":"teepot_vflag", "ifnull":"-v"}, {"subst":"teepot_tempdir_flag"}, "-w", {"subst":"fomw_teepot_wval", "ifnull":"300"}, "__SCRAMBLE_OUT__", "__FLAGSTAT_OUT__", "__CALIBRATION_PU_OUT__", "__BAM_OUT__", "__SAMTOOLS_STATS_F0x900_OUT__", "__SAMTOOLS_STATS_F0xB00_OUT__", "__BAM_STATS_OUT__", "__SEQCHKSUM_OUT__", "__SEQCHKSUM_EXTRAHASH_OUT__" ]
+		"cmd":[ "teepot", {"subst":"teepot_vflag", "ifnull":"-v"}, {"subst":"teepot_tempdir_flag"}, "-w", {"subst":"fomw_teepot_wval", "ifnull":"300"}, "__SCRAMBLE_OUT__", "__FLAGSTAT_OUT__", "__CALIBRATION_PU_OUT__", "__BAM_OUT__", "__SAMTOOLS_STATS_F0x900_OUT__", "__SAMTOOLS_STATS_F0xB00_OUT__", "__BAM_STATS_OUT__", "__SEQCHKSUM_OUT__", "__SEQCHKSUM_EXTRAHASH_OUT__","__SAMTOOLS_STATS_F0x900_BAIT_OUT__", "__SAMTOOLS_STATS_F0xB00_BAIT_OUT__"]
 	},
 	{
 		"id":"scramble",
@@ -294,11 +309,25 @@
 		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-F", {"subst":"stats_filter__F0x900"}, "-" ]
 	},
 	{
+		"id":"samtools_stats_F0x900_bait",
+		"type":"EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-F", {"subst":"stats_filter__F0x900"},"-t",{"subst":"bait_regions_file"}, "-" ]
+	},
+	{
 		"id":"samtools_stats_F0xB00",
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
 		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-F", {"subst":"stats_filter__F0xB00"}, "-" ]
+	},
+	{
+		"id":"samtools_stats_F0xB00_bait",
+		"type":"EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-F", {"subst":"stats_filter__F0xB00"},"-t",{"subst":"bait_regions_file"},"-" ]
 	},
 	{
 		"id":"seqchksum",
@@ -346,6 +375,8 @@
 	{ "id":"seqchksum_extrahash_file", "type":"OUTFILE", "name":{"subst":"seqchksum_extrahash_file"} },
 	{ "id":"stats_F0x900_file", "type":"OUTFILE", "name":{"subst":"stats_F0x900_file"} },
 	{ "id":"stats_F0xB00_file", "type":"OUTFILE", "name":{"subst":"stats_F0xB00_file"} },
+	{ "id":"stats_F0x900_bait_file", "type":"OUTFILE", "name":{"subst":"stats_F0x900_bait_file"} },
+	{ "id":"stats_F0xB00_bait_file", "type":"OUTFILE", "name":{"subst":"stats_F0xB00_bait_file"} },
 	{ "id":"flagstat_file", "type":"OUTFILE", "name":{"subst":"flagstat_file"} },
 	{
 		"id":"flagstat_filter",
@@ -381,6 +412,8 @@
 	{ "id":"md5_to_postprocess", "from":"scramble_md5", "to":"postprocess_md5" },
 	{ "id":"bmdmw_to_sts_F0x900", "from":"bmd_multiway:__SAMTOOLS_STATS_F0x900_OUT__", "to":"samtools_stats_F0x900" },
 	{ "id":"bmdmw_to_sts_F0xB00", "from":"bmd_multiway:__SAMTOOLS_STATS_F0xB00_OUT__", "to":"samtools_stats_F0xB00" },
+	{ "id":"bmdmw_to_sts_F0x900_bait", "from":"bmd_multiway:__SAMTOOLS_STATS_F0x900_BAIT_OUT__", "to":"samtools_stats_F0x900_bait" },
+	{ "id":"bmdmw_to_sts_F0xB00_bait", "from":"bmd_multiway:__SAMTOOLS_STATS_F0xB00_BAIT_OUT__", "to":"samtools_stats_F0xB00_bait" },
 	{ "id":"bmdmw_to_bam_stats", "from":"bmd_multiway:__BAM_STATS_OUT__", "to":"bam_stats" },
 	{ "id":"bmdmw_to_calibration_pu", "from":"bmd_multiway:__CALIBRATION_PU_OUT__", "to":"calibration_pu" },
 	{ "id":"bmdmw_to_seqchksum", "from":"bmd_multiway:__SEQCHKSUM_OUT__", "to":"seqchksum" },
@@ -397,6 +430,8 @@
 	{ "id":"scs_extrahash_to_file", "from":"seqchksum_extrahash", "to":"seqchksum_extrahash_file" },
 	{ "id":"samtools_stats_F0x900_to_file", "from":"samtools_stats_F0x900", "to":"stats_F0x900_file" },
 	{ "id":"samtools_stats_F0xB00_to_file", "from":"samtools_stats_F0xB00", "to":"stats_F0xB00_file" },
+	{ "id":"samtools_stats_F0x900_bait_to_file", "from":"samtools_stats_F0x900_bait", "to":"stats_F0x900_bait_file" },
+	{ "id":"samtools_stats_F0xB00_bait_to_file", "from":"samtools_stats_F0xB00_bait", "to":"stats_F0xB00_bait_file" },
 	{ "id":"flagstat_to_file", "from":"flagstat", "to":"flagstat_file" },
 	{ "id":"cscs_to_file", "from":"cram_seqchksum", "to":"seqchksum_file_cram" },
 	{ "id":"cscsfile_to_cmp", "from":"seqchksum_file_cram", "to":"cmp_seqchksum:__CRAM_SEQCHKSUM_IN__" }

--- a/data/vtlib/post_alignment.json
+++ b/data/vtlib/post_alignment.json
@@ -87,7 +87,15 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd":["bam12auxmerge", "level=0", "rankstrip=1", "ranksplit=0", "zztoname=0", "clipreinsert=1", "__NO_ALN_BAM_IN__"]
+		"cmd":[
+			"bam12auxmerge",
+			"level=0",
+			{"subst":"rankstrip_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "rankstrip", {"subst":"rankstrip_val", "required":"yes", "ifnull":"1"} ],"postproc":{"op":"concat","pad":"="}}}},
+			"ranksplit=0",
+			"zztoname=0",
+			{"subst":"clipreinsert_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "clipreinsert", {"subst":"clipreinsert_val", "required":"yes", "ifnull":"1"} ],"postproc":{"op":"concat","pad":"="}}}},
+			"__NO_ALN_BAM_IN__"
+		]
 	}
 ],
 "edges":[

--- a/data/vtlib/pre_alignment.json
+++ b/data/vtlib/pre_alignment.json
@@ -25,7 +25,13 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd":[ "bamreset", "resetaux=0", "level=0", "verbose=0" ],
+		"cmd":[
+			"bamreset",
+			{"subst":"resetaux_flag","required":"no","ifnull":{"subst_constructor":{"vals":[ "resetaux", {"subst":"resetaux_val", "required":"no", "ifnull":"0"} ],"postproc":{"op":"concat","pad":"="}}}},
+			{"subst":"auxfilter_flag","required":"no"},
+			"level=0",
+			"verbose=0"
+		],
 		"comment":"Alignment removal also required for bamadapterclip (at least 0.0.142)"
 	},
 	{

--- a/t/10-vtfp-noop.t
+++ b/t/10-vtfp-noop.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use File::Slurp;
+use Perl6::Slurp;
+use JSON;
+
+my $template = q[t/data/10-vtfp-noop.json];
+
+{
+# the template contains nodes and edges with no parameters. This test should confirm that vtfp.pl has no effect on them.
+
+my $fc = from_json(read_file($template));
+my $expected->{nodes} = $fc->{nodes};
+$expected->{edges} = $fc->{edges};
+my $vtfp_results = from_json(slurp "bin/vtfp.pl --no-absolute_program_paths $template |");
+is_deeply ($vtfp_results, $expected, 'noop test');
+}
+

--- a/t/10-vtfp-splice_nodes.t
+++ b/t/10-vtfp-splice_nodes.t
@@ -7,9 +7,7 @@ use JSON;
 use File::Temp qw(tempdir);
 
 my $tdir = tempdir(CLEANUP => 1);
-my $template = q[t/data/10-vtfp-pv.json];
 my $pv_file = $tdir.q[/10-vtfp-pv.pv];
-my $processed_template = $tdir.q[/10-vtfp-pv-processed.json];
 
 # just export and reimport parameter values for a template
 subtest 'spl0' => sub {

--- a/t/10-vtfp-splice_nodes.t
+++ b/t/10-vtfp-splice_nodes.t
@@ -1,20 +1,162 @@
 use strict;
 use warnings;
 use Carp;
-use Test::More tests => 1;
+use Test::More tests => 3;
+use Test::Cmd;
+use File::Slurp;
 use Perl6::Slurp;
 use JSON;
 use File::Temp qw(tempdir);
+use Cwd;
 
-my $tdir = tempdir(CLEANUP => 1);
-my $pv_file = $tdir.q[/10-vtfp-pv.pv];
+my $tdir = tempdir(CLEANUP => 0);
+print q[tdir: ], $tdir, "\n";
+
+my $basic_linear_template = {
+		description => q[simple linear chain (stdin->stdout) of nodes],
+		version => q[1.0],
+		nodes =>
+		[
+			{
+				id => q[hello],
+				type => q[EXEC],
+				use_STDIN => JSON::false,
+				use_STDOUT => JSON::true,
+				cmd => [ q/echo/, q/Hello/ ],
+			},
+			{
+				id => q[rev],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/rev/ ]
+			},
+			{
+				id => q[uc],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/tr/, q/[:lower:]/, q/[:upper:]/ ],
+			},
+			{
+				id => q[disemvowel],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/tr/, q/-d/, q/[aeiouAEIOU]/ ],
+			},
+			{
+				id => q[output],
+				type => q[OUTFILE],
+				name => q/tmp.xxx/,
+			},
+		],
+		edges =>
+		[
+			{ id => q[e0], from => q[hello], to => q[rev] },
+			{ id => q[e1], from => q[rev], to => q[uc] },
+			{ id => q[e2], from => q[uc], to => q[disemvowel] },
+			{ id => q[e3], from => q[disemvowel], to => q[output] }
+		]
+	};
+
+my $basic_multipath_template = {
+		description => q[graph with some branching],
+		version => q[1.0],
+		nodes =>
+		[
+			{
+				id => q[top],
+				type => q[EXEC],
+				use_STDIN => JSON::false,
+				use_STDOUT => JSON::true,
+				cmd => q/echo "Start" | tee __ALT_OUT__/,
+			},
+			{
+				id => q[nodeA],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ addedA\\n/#, ]
+			},
+			{
+				id => q[nodeB],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ addedB\\n/#, ]
+			},
+			{
+				id => q[tee2],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/tee/, q/__RIGHT2_OUT__/ ]
+			},
+			{
+				id => q[tee3],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/tee/, q/__RIGHT3_OUT__/, q/__MID3_OUT__/ ]
+			},
+			{
+				id => q[Aleft],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ left\\n/# ],
+			},
+			{
+				id => q[Aright],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ right\\n/# ],
+			},
+			{
+				id => q[Bleft],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ left\\n/# ],
+			},
+			{
+				id => q[Bmid],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ mid\\n/# ],
+			},
+			{
+				id => q[Bright],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ right\\n/# ],
+			},
+		],
+		edges =>
+		[
+			{ id => q[e0], from => q[top], to => q[nodeA] },
+			{ id => q[e1], from => q[top:__ALT_OUT__], to => q[nodeB] },
+			{ id => q[e2], from => q[nodeA], to => q[tee2] },
+			{ id => q[e3], from => q[nodeB], to => q[tee3] },
+			{ id => q[e4], from => q[tee2], to => q[Aleft] },
+			{ id => q[e5], from => q[tee2:__RIGHT2_OUT__], to => q[Aright] },
+			{ id => q[e6], from => q[tee3], to => q[Bleft] },
+			{ id => q[e7], from => q[tee3:__MID3_OUT__], to => q[Bmid] },
+			{ id => q[e8], from => q[tee3:__RIGHT3_OUT__], to => q[Bright] },
+		]
+	};
 
 # just export and reimport parameter values for a template
 subtest 'spl0' => sub {
 	plan tests => 2;
 
-	my $template = q[t/data/10-vtfp-splice_nodes_00.json];
-	my $processed_template = $tdir.q[/10-vtfp-splice_nodes_00-processed.json];
+	my $template = $tdir.q[/10-vtfp-splice_nodes_00.json];
+	my $template_contents = to_json($basic_linear_template);
+	write_file($template, $template_contents);
 
 	my $vtfp_results = from_json(slurp "bin/vtfp.pl -no-absolute_program_paths -verbosity_level 0 -splice_nodes rev $template |");
 	my $expected = { nodes =>
@@ -34,6 +176,13 @@ subtest 'spl0' => sub {
 					cmd => [ q/tr/, q/[:lower:]/, q/[:upper:]/ ],
 				},
 				{
+					id => q[disemvowel],
+					type => q[EXEC],
+					use_STDIN => JSON::true,
+					use_STDOUT => JSON::true,
+					cmd => [ q/tr/, q/-d/, q/[aeiouAEIOU]/ ],
+				},
+				{
 					id => q[output],
 					type => q[OUTFILE],
 					name => q/tmp.xxx/,
@@ -41,7 +190,8 @@ subtest 'spl0' => sub {
 			],
 			edges =>
 			[
-				{ id => q/e2/, from => q/uc/, to => q/output/ },
+				{ id => q/e2/, from => q/uc/, to => q/disemvowel/ },
+				{ id => q/e3/, from => q/disemvowel/, to => q/output/ },
 				{ id => q/hello_to_uc/, from => q/hello/, to => q/uc/ },
 			]
 		};
@@ -80,6 +230,212 @@ subtest 'spl0' => sub {
 
 	is_deeply ($vtfp_results, $expected, '(spl0) remove last two nodes in the chain');
 
+};
+
+# wildcard tests
+subtest 'spl1' => sub {
+	plan tests => 4;
+
+	my $template = $tdir.q[/10-vtfp-splice_nodes_01.json];
+	my $template_contents = to_json($basic_linear_template);
+	write_file($template, $template_contents);
+
+	my $vtfp_results = from_json(slurp "bin/vtfp.pl -no-absolute_program_paths -verbosity_level 0 -splice_nodes \'.*[rs]e.*\' $template |");
+	my $expected = {
+			nodes =>
+			[
+				{
+					id => q[hello],
+					type => q[EXEC],
+					use_STDIN => JSON::false,
+					use_STDOUT => JSON::true,
+					cmd => [ q/echo/, q/Hello/ ],
+				},
+				{
+					id => q[uc],
+					type => q[EXEC],
+					use_STDIN => JSON::true,
+					use_STDOUT => JSON::true,
+					cmd => [ q/tr/, q/[:lower:]/, q/[:upper:]/ ],
+				},
+				{
+					id => q[output],
+					type => q[OUTFILE],
+					name => q/tmp.xxx/,
+				},
+			],
+			edges =>
+			[
+				{ id => q/hello_to_uc/, from => q/hello/, to => q/uc/ },
+				{ id => q/uc_to_output/, from => q/uc/, to => q/output/ },
+			]
+		};
+
+	is_deeply ($vtfp_results, $expected, '(spl1) spliced out nodes selected with wildcard');
+
+	$vtfp_results = from_json(slurp "bin/vtfp.pl -no-absolute_program_paths -verbosity_level 0 -prune_nodes \'disemv.*-\' $template |");
+	$expected = {
+			nodes =>
+			[
+				{
+					id => q[hello],
+					type => q[EXEC],
+					use_STDIN => JSON::false,
+					use_STDOUT => JSON::true,
+					cmd => [ q/echo/, q/Hello/ ],
+				},
+				{
+					id => q[rev],
+					type => q[EXEC],
+					use_STDIN => JSON::true,
+					use_STDOUT => JSON::true,
+					cmd => [ q/rev/ ]
+				},
+				{
+					id => q[uc],
+					type => q[EXEC],
+					use_STDIN => JSON::true,
+					use_STDOUT => JSON::false,
+					cmd => [ q/tr/, q/[:lower:]/, q/[:upper:]/ ],
+				}
+			],
+			edges =>
+			[
+				{ id => q[e0], from => q[hello], to => q[rev] },
+				{ id => q[e1], from => q[rev], to => q[uc] }
+			]
+		};
+
+	is_deeply ($vtfp_results, $expected, '(spl1) prune two (non-sequential) nodes using wildcard');
+
+	$template = $tdir.q[/10-vtfp-splice_nodes_01a.json];
+	$template_contents = to_json($basic_multipath_template);
+	write_file($template, $template_contents);
+
+	$vtfp_results = from_json(slurp "bin/vtfp.pl -no-absolute_program_paths -verbosity_level 0 -prune_nodes \'tee2-;tee3-\' $template |");
+	$expected = {
+		nodes =>
+		[
+			{
+				id => q[top],
+				type => q[EXEC],
+				use_STDIN => JSON::false,
+				use_STDOUT => JSON::true,
+				cmd => q/echo "Start" | tee __ALT_OUT__/,
+			},
+			{
+				id => q[nodeA],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::false,
+				cmd => [ q/sed/, q/-e/, q#s/$/ addedA\\n/#, ]
+			},
+			{
+				id => q[nodeB],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::false,
+				cmd => [ q/sed/, q/-e/, q#s/$/ addedB\\n/#, ]
+			},
+		],
+		edges =>
+		[
+			{ id => q[e0], from => q[top], to => q[nodeA] },
+			{ id => q[e1], from => q[top:__ALT_OUT__], to => q[nodeB] }
+		]
+	};
+
+	is_deeply ($vtfp_results, $expected, '(spl1) prune ends of two branches using wildcard');
+
+	$vtfp_results = from_json(slurp "bin/vtfp.pl -no-absolute_program_paths -verbosity_level 0 -prune_nodes \'tee.*:__RIGHT.*-\' $template |");
+	$expected = {
+		nodes =>
+		[
+			{
+				id => q[top],
+				type => q[EXEC],
+				use_STDIN => JSON::false,
+				use_STDOUT => JSON::true,
+				cmd => q/echo "Start" | tee __ALT_OUT__/,
+			},
+			{
+				id => q[nodeA],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ addedA\\n/#, ]
+			},
+			{
+				id => q[nodeB],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ addedB\\n/#, ]
+			},
+			{
+				id => q[tee2],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/tee/, ]
+			},
+			{
+				id => q[tee3],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/tee/, q/__MID3_OUT__/ ]
+			},
+			{
+				id => q[Aleft],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ left\\n/# ],
+			},
+			{
+				id => q[Bleft],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ left\\n/# ],
+			},
+			{
+				id => q[Bmid],
+				type => q[EXEC],
+				use_STDIN => JSON::true,
+				use_STDOUT => JSON::true,
+				cmd => [ q/sed/, q/-e/, q#s/$/ mid\\n/# ],
+			},
+		],
+		edges =>
+		[
+			{ id => q[e0], from => q[top], to => q[nodeA] },
+			{ id => q[e1], from => q[top:__ALT_OUT__], to => q[nodeB] },
+			{ id => q[e2], from => q[nodeA], to => q[tee2] },
+			{ id => q[e3], from => q[nodeB], to => q[tee3] },
+			{ id => q[e4], from => q[tee2], to => q[Aleft] },
+			{ id => q[e6], from => q[tee3], to => q[Bleft] },
+			{ id => q[e7], from => q[tee3:__MID3_OUT__], to => q[Bmid] },
+		]
+	};
+
+	is_deeply ($vtfp_results, $expected, '(spl1) prune ends of two branches using wildcard');
+};
+
+# exec failures
+subtest 'spl2' => sub {
+	plan tests => 2;
+
+	my $template = $tdir.q[/10-vtfp-splice_nodes_02.json];
+	my $template_contents = to_json($basic_linear_template);
+	write_file($template, $template_contents);
+
+	my$odir = getcwd();
+	my $test = Test::Cmd->new( prog => $odir.'/bin/vtfp.pl', workdir => q());
+	ok($test, 'made test object');
+	my $exit_status = $test->run(chdir => $test->curdir, args => qq[-no-absolute_program_paths -verbosity_level 0 -splice_nodes \'rev;uc\' $template]);
+	cmp_ok($exit_status>>8, q(==), 255, "expected exit status of 255 for splice fail test (two sequential nodes without port spec)");
 };
 
 1;

--- a/t/10-vtfp-splice_nodes.t
+++ b/t/10-vtfp-splice_nodes.t
@@ -1,0 +1,87 @@
+use strict;
+use warnings;
+use Carp;
+use Test::More tests => 1;
+use Perl6::Slurp;
+use JSON;
+use File::Temp qw(tempdir);
+
+my $tdir = tempdir(CLEANUP => 1);
+my $template = q[t/data/10-vtfp-pv.json];
+my $pv_file = $tdir.q[/10-vtfp-pv.pv];
+my $processed_template = $tdir.q[/10-vtfp-pv-processed.json];
+
+# just export and reimport parameter values for a template
+subtest 'spl0' => sub {
+	plan tests => 2;
+
+	my $template = q[t/data/10-vtfp-splice_nodes_00.json];
+	my $processed_template = $tdir.q[/10-vtfp-splice_nodes_00-processed.json];
+
+	my $vtfp_results = from_json(slurp "bin/vtfp.pl -no-absolute_program_paths -verbosity_level 0 -splice_nodes rev $template |");
+	my $expected = { nodes =>
+			[
+				{
+					id => q[hello],
+					type => q[EXEC],
+					use_STDIN => JSON::false,
+					use_STDOUT => JSON::true,
+					cmd => [ q/echo/, q/Hello/ ],
+				},
+				{
+					id => q[uc],
+					type => q[EXEC],
+					use_STDIN => JSON::true,
+					use_STDOUT => JSON::true,
+					cmd => [ q/tr/, q/[:lower:]/, q/[:upper:]/ ],
+				},
+				{
+					id => q[output],
+					type => q[OUTFILE],
+					name => q/tmp.xxx/,
+				},
+			],
+			edges =>
+			[
+				{ id => q/e2/, from => q/uc/, to => q/output/ },
+				{ id => q/hello_to_uc/, from => q/hello/, to => q/uc/ },
+			]
+		};
+
+	is_deeply ($vtfp_results, $expected, '(spl0) one node in a chain spliced out');
+
+	$vtfp_results = from_json(slurp "bin/vtfp.pl -no-absolute_program_paths -verbosity_level 0 -splice_nodes \'uc-\' $template |");
+	$expected = { nodes =>
+			[
+				{
+					id => q[hello],
+					type => q[EXEC],
+					use_STDIN => JSON::false,
+					use_STDOUT => JSON::true,
+					cmd => [ q/echo/, q/Hello/ ],
+				},
+				{
+					id => q[rev],
+					type => q[EXEC],
+					use_STDIN => JSON::true,
+					use_STDOUT => JSON::true,
+					cmd => [ q/rev/ ],
+				},
+				{
+					id => q[STDOUT_00000],
+					name => q[/dev/stdout],
+					type => q[OUTFILE],
+				},
+			],
+			edges =>
+			[
+				{ id => q/e0/, from => q/hello/, to => q/rev/ },
+				{ id => q/rev_to_STDOUT/, from => q/rev/, to => q/STDOUT_00000/ },
+			]
+		};
+
+	is_deeply ($vtfp_results, $expected, '(spl0) remove last two nodes in the chain');
+
+};
+
+1;

--- a/t/data/10-vtfp-noop.json
+++ b/t/data/10-vtfp-noop.json
@@ -1,0 +1,24 @@
+{
+"description":"template with nothing for vtfp to process (no parameter substition, for example); used to demonstrate that vtfp processing (without absolute_program_paths) will have no effect on the nodes and edges",
+"version":"1.0",
+"nodes":[
+	{
+		"id":"hello",
+		"type":"EXEC",
+		"use_STDIN":false,
+		"use_STDOUT":true,
+		"cmd":[ "echo", "Hello" ]
+	},
+	{
+		"id":"rev",
+		"type":"EXEC",
+		"use_STDIN":true,
+		"use_STDOUT":true,
+		"cmd":[ "rev" ]
+	}
+],
+"edges":[
+	{ "id":"e0", "from":"hello", "to":"rev" }
+]
+}
+

--- a/t/data/10-vtfp-splice_nodes_00.json
+++ b/t/data/10-vtfp-splice_nodes_00.json
@@ -1,0 +1,38 @@
+{
+"description":"test node splicing feature",
+"version":"1.0",
+"nodes":[
+	{
+		"id":"hello",
+		"type":"EXEC",
+		"use_STDIN":false,
+		"use_STDOUT":true,
+		"cmd":[ "echo", "Hello" ]
+	},
+	{
+		"id":"rev",
+		"type":"EXEC",
+		"use_STDIN":true,
+		"use_STDOUT":true,
+		"cmd":[ "rev" ]
+	},
+	{
+		"id":"uc",
+		"type":"EXEC",
+		"use_STDIN":true,
+		"use_STDOUT":true,
+		"cmd":[ "tr", "[:lower:]", "[:upper:]" ]
+	},
+	{
+		"id":"output",
+		"type":"OUTFILE",
+		"name":"tmp.xxx"
+	}
+],
+"edges":[
+	{ "id":"e0", "from":"hello", "to":"rev" },
+	{ "id":"e1", "from":"rev", "to":"uc" },
+	{ "id":"e2", "from":"uc", "to":"output" }
+]
+}
+


### PR DESCRIPTION
vtfp.pl:
  New node splicing function 
  commas can be now be escaped in arguments to -keys, -vals, -param_vals flags (not yet UTF8-friendly)
