### PR TITLE
Bambi i2b and decode

### DIFF
--- a/data/vtlib/bamindexdecoder.json
+++ b/data/vtlib/bamindexdecoder.json
@@ -21,7 +21,7 @@
 			"postproc":{"op":"concat", "pad":""}
 		}
 	},
-	{"id":"bamindex_decoder_opt","required":"yes","default":{"subst_constructor":{"vals":[ "bamindexdecoder", {"subst":"bid_implementation", "ifnull":"samtools"}, "cmd" ],"postproc":{"op":"concat","pad":"_"}}}},
+	{"id":"bamindex_decoder_opt","required":"yes","default":{"subst_constructor":{"vals":[ "bamindexdecoder", {"subst":"bid_implementation", "ifnull":"bambi"}, "cmd" ],"postproc":{"op":"concat","pad":"_"}}}},
 	{"id":"bamindexdecoder_cmd", "default":{"subst":{"subst":"bamindex_decoder_opt","required":"yes"}}},
 	{
 		"id":"bamindexdecoder_java_cmd",
@@ -41,11 +41,11 @@
 		}
 	},
 	{
-		"id":"bamindexdecoder_samtools_cmd",
+		"id":"bamindexdecoder_bambi_cmd",
 		"required":"yes",
 		"subst_constructor":{
 			"vals": [
-				{"subst":"bamindexdecoder_executable","ifnull":{"subst":"samtools_executable"},"required":"yes"},
+				{"subst":"bamindexdecoder_executable","ifnull":"bambi","required":"yes"},
 				"decode",
 				"--metrics-file", "__METRICS_FILE_OUT__",
 				{"subst":"barcode_file_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "--barcode-file", {"subst":"barcode_file", "required":"yes"} ]}}},

--- a/data/vtlib/bcl2bam_phix_deplex_wtsi_stage1_template.json
+++ b/data/vtlib/bcl2bam_phix_deplex_wtsi_stage1_template.json
@@ -73,14 +73,6 @@
 			"postproc":{"op":"concat","pad":","}
 		}
 	},
-	{
-		"id":"i2b_sample_alias_flag",
-		"required":"yes",
-		"subst_constructor":{
-			"vals":["SAMPLE_ALIAS",{"subst":"i2b_sample_aliases"}],
-			"postproc":{"op":"concat","pad":"="}
-		}
-	},
 	{"id":"bid_opt","required":"no","default":"bamindexdecoder"},
         {
                 "id":"bid_vtf",
@@ -164,6 +156,81 @@
 			"vals":[ {"subst":"reposdir"}, "/", {"subst":"refname_phix"} ],
 			"postproc":{"op":"concat", "pad":""}
 		}
+	},
+	{"id":"illumina2bam_opt","required":"yes","default":{"subst_constructor":{"vals":[ "illumina2bam", {"subst":"i2b_implementation", "ifnull":"bambi"}, "cmd" ],"postproc":{"op":"concat","pad":"_"}}}},
+	{"id":"illumina2bam_cmd", "default":{"subst":{"subst":"illumina2bam_opt","required":"yes"}}},
+	{
+		"id":"illumina2bam_java_cmd",
+		"required":"yes",
+		"subst_constructor":{
+			"vals": [
+				{"subst":"java_cmd","ifnull":"java","required":"yes"},
+				"-Xmx1024m",
+				"-jar",{"subst":"illumina2bam_jar","required":"yes","ifnull":{"subst_constructor":{"vals":[ {"subst":"i2b_jar_path"}, "/Illumina2bam.jar" ],"postproc":{"op":"concat","pad":""}}}},
+				{"subst":"i2b_intensity_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "I", {"subst":"i2b_intensity_dir","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_basecalls_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "B", {"subst":"i2b_basecalls_dir","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_lane_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "LANE", {"subst":"i2b_lane","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_pu_flag","ifnull":{"subst_constructor":{"vals":[ "PU", {"subst":"i2b_pu"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_rg_flag","ifnull":{"subst_constructor":{"vals":[ "READ_GROUP_ID", {"subst":"i2b_rg"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_bc_seq_flag","ifnull":{"subst_constructor":{"vals":[ "BC_SEQ", {"subst":"i2b_bc_seq_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_bc_qual_flag","ifnull":{"subst_constructor":{"vals":[ "BC_QUAL", {"subst":"i2b_bc_qual_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_sec_bc_seq_flag","ifnull":{"subst_constructor":{"vals":[ "SEC_BC_SEQ", {"subst":"i2b_sec_bc_seq_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_sec_bc_qual_flag","ifnull":{"subst_constructor":{"vals":[ "SEC_BC_QUAL", {"subst":"i2b_sec_bc_qual_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_tile_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST_TILE", {"subst":"i2b_first_tile"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_tile_limit_flag","ifnull":{"subst_constructor":{"vals":[ "TILE_LIMIT", {"subst":"i2b_tile_limit"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_library_flag","ifnull":{"subst_constructor":{"vals":[ "LIBRARY_NAME", {"subst":"i2b_library_name"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_study_name_flag","ifnull":{"subst_constructor":{"vals":[ "STUDY_NAME", {"subst":"i2b_study_name"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_sample_alias_flag","ifnull":{"subst_constructor":{"vals":[ "SAMPLE_ALIAS", {"subst":"i2b_sample_aliases"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_bc_read_flag","ifnull":{"subst_constructor":{"vals":[ "BC_READ", {"subst":"i2b_bc_read"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_index_0_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST_INDEX", {"subst":"i2b_first_index_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_index_0_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL_INDEX", {"subst":"i2b_final_index_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_index_1_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST_INDEX", {"subst":"i2b_first_index_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_index_1_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL_INDEX", {"subst":"i2b_final_index_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_0_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST", {"subst":"i2b_first_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_0_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL", {"subst":"i2b_final_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_1_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST", {"subst":"i2b_first_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_1_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL", {"subst":"i2b_final_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				"OUTPUT=/dev/stdout",
+				"COMPRESSION_LEVEL=0"
+			],
+			"postproc":{"op":"pack"}
+		}
+	},
+	{
+		"id":"illumina2bam_bambi_cmd",
+		"required":"yes",
+		"subst_constructor":{
+			"vals": [
+				"bambi",
+				"i2b",
+				{"subst":"i2b_intensity_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "--intensity-dir", {"subst":"i2b_intensity_dir","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_basecalls_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "--basecalls-dir", {"subst":"i2b_basecalls_dir","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_lane_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "--lane", {"subst":"i2b_lane","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_pu_flag","ifnull":{"subst_constructor":{"vals":[ "--platform-unit", {"subst":"i2b_pu"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_rg_flag","ifnull":{"subst_constructor":{"vals":[ "--read-group-id", {"subst":"i2b_rg"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_bc_seq_flag","ifnull":{"subst_constructor":{"vals":[ "--barcode-tag", {"subst":"i2b_bc_seq_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_bc_qual_flag","ifnull":{"subst_constructor":{"vals":[ "--quality-tag", {"subst":"i2b_bc_qual_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_sec_bc_seq_flag","ifnull":{"subst_constructor":{"vals":[ "--sec-barcode-tag", {"subst":"i2b_sec_bc_seq_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_sec_bc_qual_flag","ifnull":{"subst_constructor":{"vals":[ "--sec-quality-tag", {"subst":"i2b_sec_bc_qual_val"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_tile_flag","ifnull":{"subst_constructor":{"vals":[ "--first-tile", {"subst":"i2b_first_tile"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_tile_limit_flag","ifnull":{"subst_constructor":{"vals":[ "--tile-limit", {"subst":"i2b_tile_limit"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_library_flag","ifnull":{"subst_constructor":{"vals":[ "--library-name", {"subst":"i2b_library_name"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_study_name_flag","ifnull":{"subst_constructor":{"vals":[ "--study-name", {"subst":"i2b_study_name"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_sample_alias_flag","ifnull":{"subst_constructor":{"vals":[ "--sample-alias", {"subst":"i2b_sample_aliases"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_bc_read_flag","ifnull":{"subst_constructor":{"vals":[ "--bc-read", {"subst":"i2b_bc_read"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_index_0_flag","ifnull":{"subst_constructor":{"vals":[ "--first-index-cycle", {"subst":"i2b_first_index_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_index_0_flag","ifnull":{"subst_constructor":{"vals":[ "--final-index-cycle", {"subst":"i2b_final_index_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_index_1_flag","ifnull":{"subst_constructor":{"vals":[ "--first-index-cycle", {"subst":"i2b_first_index_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_index_1_flag","ifnull":{"subst_constructor":{"vals":[ "--final-index-cycle", {"subst":"i2b_final_index_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_0_flag","ifnull":{"subst_constructor":{"vals":[ "--first-cycle", {"subst":"i2b_first_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_0_flag","ifnull":{"subst_constructor":{"vals":[ "--final-cycle", {"subst":"i2b_final_0"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_first_1_flag","ifnull":{"subst_constructor":{"vals":[ "--first-cycle", {"subst":"i2b_first_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				{"subst":"i2b_final_1_flag","ifnull":{"subst_constructor":{"vals":[ "--final-cycle", {"subst":"i2b_final_1"} ],"postproc":{"op":"concat","pad":"="}}}},
+				"--output-file=-",
+				"--compression-level=0"
+			],
+			"postproc":{"op":"pack"}
+		}
 	}
 ],
 "nodes":[
@@ -172,36 +239,8 @@
 		"type":"EXEC",
 		"use_STDIN":false,
 		"use_STDOUT":true,
-		"cmd":[
-			{"subst":"java_cmd","ifnull":"java","required":"yes"},
-			"-Xmx1024m",
-			"-jar",{"subst":"illumina2bam_jar","required":"yes","ifnull":{"subst_constructor":{"vals":[ {"subst":"i2b_jar_path"}, "/Illumina2bam.jar" ],"postproc":{"op":"concat","pad":""}}}},
-			{"subst":"i2b_intensity_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "I", {"subst":"i2b_intensity_dir","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_basecalls_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "B", {"subst":"i2b_basecalls_dir","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_lane_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "LANE", {"subst":"i2b_lane","required":"yes"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_pu_flag","ifnull":{"subst_constructor":{"vals":[ "PU", {"subst":"i2b_pu"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_rg_flag","ifnull":{"subst_constructor":{"vals":[ "READ_GROUP_ID", {"subst":"i2b_rg"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_bc_seq_flag","ifnull":{"subst_constructor":{"vals":[ "BC_SEQ", {"subst":"i2b_bc_seq_val"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_bc_qual_flag","ifnull":{"subst_constructor":{"vals":[ "BC_QUAL", {"subst":"i2b_bc_qual_val"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_sec_bc_seq_flag","ifnull":{"subst_constructor":{"vals":[ "SEC_BC_SEQ", {"subst":"i2b_sec_bc_seq_val"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_sec_bc_qual_flag","ifnull":{"subst_constructor":{"vals":[ "SEC_BC_QUAL", {"subst":"i2b_sec_bc_qual_val"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_first_tile_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST_TILE", {"subst":"i2b_first_tile"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_tile_limit_flag","ifnull":{"subst_constructor":{"vals":[ "TILE_LIMIT", {"subst":"i2b_tile_limit"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_library_flag","ifnull":{"subst_constructor":{"vals":[ "LIBRARY_NAME", {"subst":"i2b_library_name"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_study_name_flag","ifnull":{"subst_constructor":{"vals":[ "STUDY_NAME", {"subst":"i2b_study_name"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_sample_alias_flag","ifnull":{"subst_constructor":{"vals":[ "SAMPLE_ALIAS", {"subst":"i2b_sample_aliases"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_bc_read_flag","ifnull":{"subst_constructor":{"vals":[ "BC_READ", {"subst":"i2b_bc_read"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_first_index_0_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST_INDEX", {"subst":"i2b_first_index_0"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_final_index_0_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL_INDEX", {"subst":"i2b_final_index_0"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_first_index_1_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST_INDEX", {"subst":"i2b_first_index_1"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_final_index_1_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL_INDEX", {"subst":"i2b_final_index_1"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_first_0_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST", {"subst":"i2b_first_0"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_final_0_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL", {"subst":"i2b_final_0"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_first_1_flag","ifnull":{"subst_constructor":{"vals":[ "FIRST", {"subst":"i2b_first_1"} ],"postproc":{"op":"concat","pad":"="}}}},
-			{"subst":"i2b_final_1_flag","ifnull":{"subst_constructor":{"vals":[ "FINAL", {"subst":"i2b_final_1"} ],"postproc":{"op":"concat","pad":"="}}}},
-			"OUTPUT=/dev/stdout",
-			"COMPRESSION_LEVEL=0"
-		],
+		"comment":"Actual executable used depends on the value of the 12b_implementation parameter: java - use illumina2bam (default); bambi - use new bambi i2b",
+		"cmd":{"subst":"illumina2bam_cmd","required":"yes"},
 		"description":"Create the initial BAM file from the data generated by the Illumina machine"
 	},
 	{


### PR DESCRIPTION
make bambi the default for the i2b (Illumina2bam) and decode (BamIndexDecoder) functions

ensure parameters are in place to allow swap to older java implementations when required:
  i2b_implementation - values: "bambi", "java"
  bid_implementation - values: "bambi", "java"
