### PR TITLE
coord sort to bamsormadup

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 CHANGES LOG
 -----------
 
+ - use threaded bamsormadup in place of bamsort for coord sort
+
 release 0.18.2
  - propagate any 'AH' fields provided by the aligner when providing full SQ headers (bwa0.7.15)
  - fix bamindexdecoder.json template: add pack option to bamindexdecoder_java_cmd array to handle undefined parameters; change default implementation from "samtools decode" to java BamIndexDecoder

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -25,6 +25,13 @@
 		}
 	},
 	{
+		"id":"bsmd_threads",
+		"subst_constructor":{
+			"vals":[ "threads", {"subst":"aligner_numthreads"} ],
+			"postproc":{"op":"concat", "pad":"="}
+		}
+	},
+	{
 		"id":"scramble_reference_flag",
 		"required":"no",
 		"comment":"flag will disappear unless scramble_reference_fasta value is given (allows unaligned cram)",
@@ -217,7 +224,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd": [ "bamsort", "SO=coordinate", "level=0", "verbose=0", "fixmate=1", "adddupmarksupport=1", {"subst":"bs_tmpfile_flag"} ]
+		"cmd": [ "bamsormadup", {"subst":"bsmd_threads"}, "SO=coordinate", "level=0", "verbose=0", "fixmate=1", "adddupmarksupport=1", {"subst":"bs_tmpfile_flag"} ]
 	},
 	{
 		"id":"bammarkduplicates",


### PR DESCRIPTION
Try using bamsormadup for final coord sort now Biobambam has had
a second stage memory fix

This reverts commit 96f2305d6ffd085704bce4f1754616e4a3decd5b.

Conflicts:

	Changes

Conflicts:

	Changes
	data/vtlib/final_output_prep.json