### PR TITLE
flag changes for bwa 0.7.15 (mem)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 CHANGES LOG
 -----------
 
+ - bwa mem flags default changes and additions
+    don't use -T by default
+    [new flag] use -K 100000000 (reads per thread, large value to make alignment runs replicable)
+    [new flag] use -Y to soft clip supplementary alignments instead of hard clipping
  - use threaded bamsormadup in place of bamsort for coord sort
 
 release 0.18.2

--- a/data/vtlib/bwa_mem_alignment.json
+++ b/data/vtlib/bwa_mem_alignment.json
@@ -20,13 +20,20 @@
                 "required": "no",
                 "comment":"this will expand to a set of subst_param elements"
         },
-	{"id":"bwa_mem_T_value","required":"no","default":"0"},
+	{"id":"bwa_mem_T_value","required":"no","comment":"default value of 0 removed when moving to bwa0.7.15 (so new default is no -T flag)"},
 	{
 		"id":"bwa_mem_T_flag",
 		"required":"no",
 		"subst_constructor":{ "vals":[ "-T", {"subst":"bwa_mem_T_value"} ] }
 	},
-	{"id":"bwa_mem_p_flag","required":"no","default":"-p","comment":"by default, paired alignment is assumed"}
+	{"id":"bwa_mem_K_value","required":"no","default":"100000000","comment":"unset this value to remove -K flag"},
+	{
+		"id":"bwa_mem_K_flag",
+		"required":"no",
+		"subst_constructor":{ "vals":[ "-K", {"subst":"bwa_mem_K_value"} ] }
+	},
+	{"id":"bwa_mem_p_flag","required":"no","default":"-p","comment":"by default, paired alignment is assumed"},
+	{"id":"bwa_mem_Y_flag","required":"no","default":"-Y","comment":"by default, supplementary alignment sequences will be soft clipped instead of hard clipped"}
 ],
 "nodes":[
 	{
@@ -38,7 +45,7 @@
 		"id":"bwa_mem",
 		"comment":"presuming interleaved FR fastq records (-p flag), output all records (-T 0)",
 		"type":"EXEC",
-		"cmd":[ {"subst":"bwa_executable"}, "mem", "-t", {"subst":"aligner_numthreads"}, {"subst":"bwa_mem_p_flag"}, {"subst":"bwa_mem_T_flag"}, "__DB_PREFIX_REFERENCE_GENOME_IN__", "__FQ_IN__" ]
+		"cmd":[ {"subst":"bwa_executable"}, "mem", "-t", {"subst":"aligner_numthreads"}, {"subst":"bwa_mem_p_flag"},{"subst":"bwa_mem_Y_flag"}, {"subst":"bwa_mem_T_flag"}, {"subst":"bwa_mem_K_flag"}, "__DB_PREFIX_REFERENCE_GENOME_IN__", "__FQ_IN__" ]
 	},
         {
                 "id":"samtobam",


### PR DESCRIPTION
  don't use -T by default
  use -K 100000000 (reads per thread, large value to make alignment runs replicable)
  use -Y to soft clip supplementary alignments instead of hard clipping