### PR TITLE
flag removed from seqchksum_merge.pl command in merge_aligned template

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 CHANGES LOG
 -----------
-
+ - removal of -n 1 flag with seqchksum_merge.pl command in merge_aligned template to maintain current behaviour 
  - bwa mem flags default changes and additions
     don't use -T by default
     [new flag] use -K 100000000 (reads per thread, large value to make alignment runs replicable)

--- a/data/vtlib/merge_aligned.json
+++ b/data/vtlib/merge_aligned.json
@@ -97,7 +97,7 @@
 		"use_STDIN": false,
 		"use_STDOUT": true,
 		"orig_cmd":{"subst":"merge_seqchksum"},
-		"cmd":[ "seqchksum_merge.pl", "-n 1",{"subst":"incrams_seqchksum"} ],
+		"cmd":[ "seqchksum_merge.pl", {"subst":"incrams_seqchksum"} ],
 		"description": "merge individual cram seqchksum (crc32prod) files"
 	},
 	{


### PR DESCRIPTION
...so that head -5 returns the same lines as before and cmp_seqchksumdefault does not complain