### PR TITLE
vtfp.pl - enable detection of infinite recursion in parameter substitution

### DIFF
--- a/bin/vtfp.pl
+++ b/bin/vtfp.pl
@@ -556,6 +556,8 @@ sub fetch_subst_value {
 		return;
 	}
 
+	push @{$irp}, $param_name;
+
 	my $param_store = $params->{param_store};
 
 	if(defined $param_store->[0]->{varnames}->{$param_name} and exists $param_store->[0]->{varnames}->{$param_name}->{_value}) { # allow undef value


### PR DESCRIPTION
enable detection of infinite recursion in parameter substitution and add test triggering failure