### PR TITLE
STAR Aligner alignment template

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 CHANGES LOG
 -----------
 
+ - add new templates for STAR alignment and Salmon
+
 release 0.18.6
  - Y-split fixes
      When processing VTFILE nodes, make sure that parameters are reevaluated locally instead of naively inheriting values

--- a/MANIFEST
+++ b/MANIFEST
@@ -25,10 +25,12 @@ data/vtlib/pre_alignment.json
 data/vtlib/pre_alignment_realign.json
 data/vtlib/README.vtlib
 data/vtlib/realignment_wtsi_template.json
+data/vtlib/salmon_alignment.json
 data/vtlib/seqchksum.json
 data/vtlib/seqchksum_hs.json
 data/vtlib/seqchksum_realign.json
 data/vtlib/split_by_chromosome.json
+data/vtlib/star_alignment.json
 data/vtlib/tophat2_alignment.json
 examples/bwa_aln_cfg.png
 examples/bwa_mem/bwa_mem_alignment.vtf

--- a/data/vtlib/salmon_alignment.json
+++ b/data/vtlib/salmon_alignment.json
@@ -1,0 +1,130 @@
+{
+"version":"1.0",
+"description":"steps in the alignment pipeline perform a checksum-based comparison of input and output (bam) data. Final validation step in alignment pipeline",
+"subgraph_io":{
+	"ports":{
+		"inputs":{
+				"fq1":"salmon:__FQ1_IN__",
+				"fq2":"salmon:__FQ2_IN__"
+		}
+	}
+},
+"subst_params":[
+	{
+		"id":"salmon_dir",
+		"required":"no",
+		"default":"salmon_quant"
+	},
+	{
+		"id":"salmon_out",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"} ],
+			"postproc":{"op":"concat","pad":""}
+		}
+	},
+	{
+		"id":"quant",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/quant.sf" ],
+			"postproc":{"op":"concat","pad":""}
+		},
+		"default":"salmon_quant/quant.sf"
+	},
+	{
+		"id":"quant_genes",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/quant.genes.sf" ],
+			"postproc":{"op":"concat","pad":""}
+		},
+		"default":"salmon_quant/quant.genes.sf"
+	},
+	{
+		"id":"lib_format_counts",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/lib_format_counts.json" ],
+			"postproc":{"op":"concat","pad":""}
+		},
+		"default":"salmon_quant/lib_format_counts.json"
+	},
+	{
+		"id":"libparams",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/libParams" ],
+			"postproc":{"op":"concat","pad":""}
+		},
+		"default":"salmon_quant/libParams"
+	},
+	{
+		"id":"cmd_info",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/cmd_info.json" ],
+			"postproc":{"op":"concat","pad":""}
+		},
+		"default":"salmon_quant/cmd_info.json"
+	},
+	{
+		"id":"zip_target",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".salmon_quant.zip" ],
+			"postproc":{"op":"concat","pad":""}
+		}
+	},
+	{
+		"id":"gene_mapping_flag",
+		"required":"no",
+		"subst_constructor":{
+			"vals":[ "--geneMap=", {"subst":"annotation_val"} ],
+			"postproc":{"op":"concat","pad":""}
+		}
+	},
+	{
+		"id":"salmon_transcriptome_val",
+		"required":"yes"
+	}
+],
+"nodes":[
+	{
+		"id":"salmon",
+		"type":"EXEC",
+		"use_STDIN": false,
+		"use_STDOUT": true,
+		"cmd":[
+				"salmon",
+				"--no-version-check",
+				"quant",
+				"--index", {"subst":"salmon_transcriptome_val"},
+				"--libType", "A",
+				"--mates1", "__FQ1_IN__",
+				"--mates2", "__FQ2_IN__",
+				{"subst":"gene_mapping_flag"},
+				{"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-p", {"subst":"b2c_mt_val"} ]}}},
+				"--output", {"subst":"salmon_out"}
+		]
+	},
+	{
+		"id":"zip_salmon_quant",
+		"type":"EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": false,
+		"cmd":[ 
+				"zip", "-r",
+				{"subst":"zip_target"},
+				{"subst":"quant"},
+				{"subst":"quant_genes"},
+				{"subst":"lib_format_counts"},
+				{"subst":"libparams"},
+				{"subst":"cmd_info"}
+			  ]
+	}
+],
+"edges":[
+	{ "id":"salmon_to_zip_salmon_quant", "from":"salmon", "to":"zip_salmon_quant"}
+]
+}

--- a/data/vtlib/salmon_alignment.json
+++ b/data/vtlib/salmon_alignment.json
@@ -4,8 +4,8 @@
 "subgraph_io":{
 	"ports":{
 		"inputs":{
-				"fq1":"salmon:__FQ1_IN__",
-				"fq2":"salmon:__FQ2_IN__"
+				"fastq1":"salmon:__FQ1_IN__",
+				"fastq2":"salmon:__FQ2_IN__"
 		}
 	}
 },

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -142,20 +142,30 @@
                             }
     },
     {
-        "id":"cp_chimeric_sam_target",
+        "id":"scramble_chimeric_sam_target",
         "required":"no",
         "subst_constructor":{
-                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".chimeric.sam" ],
+                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".chimeric.cram" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
     },
     {
-        "id":"cp_totranscriptome_bam_target",
+        "id":"scramble_totranscriptome_bam_target",
         "required":"no",
         "subst_constructor":{
-                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".totranscriptome.bam" ],
+                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".totranscriptome.cram" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
+    },
+    {
+        "id":"scramble_genome_reference_flag",
+        "required":"no",
+        "subst_constructor":{ "vals":[ "-r", {"subst":"reference_genome_fasta"} ] }
+    },
+    {
+        "id":"scramble_transcriptome_reference_flag",
+        "required":"no",
+        "subst_constructor":{ "vals":[ "-r", {"subst":"reference_transcriptome_fasta"} ] }
     },
     {
         "id":"cp_junctions_tab_target",
@@ -244,18 +254,38 @@
         "name":{"subst":"readspergene_tab"}
     },
     {
-        "id":"cp_chimeric_sam",
+        "id":"scramble_chimeric_sam",
         "type":"EXEC",
         "use_STDIN": false,
         "use_STDOUT": false,
-        "cmd":[ "cp", "__SRC_CHIMERIC_SAM_IN__", {"subst":"cp_chimeric_sam_target"} ]
+        "cmd":[
+                "scramble",
+                {"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-t", {"subst":"b2c_mt_val"} ]}}},
+                {"subst":"b2c_fmtver", "ifnull":{"subst_constructor":{ "vals":[ "-V", {"subst":"b2c_format_version"} ]}}},
+                {"subst":"b2c_compress_level", "ifnull":"-7"},
+                "-I", "sam",
+                "-O", "cram",
+                {"subst":"scramble_genome_reference_flag"},
+                "__SRC_CHIMERIC_SAM_IN__",
+                {"subst":"scramble_chimeric_sam_target"}
+        ]
     },
     {
-        "id":"cp_totranscriptome_bam",
+        "id":"scramble_totranscriptome_bam",
         "type":"EXEC",
         "use_STDIN": false,
         "use_STDOUT": false,
-        "cmd":[ "cp", "__SRC_TOTRANSCRIPTOME_BAM_IN__", {"subst":"cp_totranscriptome_bam_target"} ]
+        "cmd":[
+                "scramble",
+                {"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-t", {"subst":"b2c_mt_val"} ]}}},
+                {"subst":"b2c_fmtver", "ifnull":{"subst_constructor":{ "vals":[ "-V", {"subst":"b2c_format_version"} ]}}},
+                {"subst":"b2c_compress_level", "ifnull":"-7"},
+                "-I", "bam",
+                "-O", "cram",
+                {"subst":"scramble_transcriptome_reference_flag"},
+                "__SRC_TOTRANSCRIPTOME_BAM_IN__",
+                {"subst":"scramble_totranscriptome_bam_target"}
+        ]
     },
     {
         "id":"cp_junctions_tab",
@@ -279,9 +309,9 @@
     { "id":"fq2_to_star", "from":"fq2", "to":"star:__FQ2_IN__" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
     { "id":"star_to_chimeric_sam", "from":"star", "to":"chimeric_sam" },
-    { "id":"cp_chimeric_sam", "from":"chimeric_sam", "to":"cp_chimeric_sam:__SRC_CHIMERIC_SAM_IN__" },
+    { "id":"scramble_chimeric_sam", "from":"chimeric_sam", "to":"scramble_chimeric_sam:__SRC_CHIMERIC_SAM_IN__"},
     { "id":"star_to_totranscriptome_bam", "from":"star", "to":"totranscriptome_bam" },
-    { "id":"cp_totranscriptome_bam", "from":"totranscriptome_bam", "to":"cp_totranscriptome_bam:__SRC_TOTRANSCRIPTOME_BAM_IN__" },
+    { "id":"scramble_totranscriptome_bam", "from":"totranscriptome_bam", "to":"scramble_totranscriptome_bam:__SRC_TOTRANSCRIPTOME_BAM_IN__" },
     { "id":"star_to_junctions_tab", "from":"star", "to":"junctions_tab" },
     { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:__SRC_JUNCTIONS_TAB_IN__" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -55,19 +55,19 @@
                             }
     },
     {
-        "id":"star_dir","required":"no","default":"star_out"
+        "id":"star_dir","required":"no","default":"."
     },
     {
         "id":"star_out",
         "required":"no",
-        "default": "star_out",
         "subst_constructor":{
-                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/" ],
+                                "vals":[ {"subst":"star_dir"}, "/", "_", {"subst":"rpt"}, "_" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
     },
     {
-        "id":"transcriptome_subpath","required":"no"
+        "id":"transcriptome_subpath",
+        "required":"no"
     },
     {
         "id":"sjdb_annotation_val",
@@ -108,36 +108,32 @@
     {
         "id":"junctions_tab",
         "required":"no",
-        "default":"star_out/SJ.out.tab",
         "subst_constructor":{
-                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/SJ.out.tab" ],
+                                "vals":[ {"subst":"star_out"}, "SJ.out.tab" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
     },
     {
         "id":"totranscriptome_bam",
         "required":"no",
-        "default":"star_out/Aligned.toTranscriptome.out.bam",
         "subst_constructor":{
-                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/Aligned.toTranscriptome.out.bam" ],
+                                "vals":[ {"subst":"star_out"}, "Aligned.toTranscriptome.out.bam" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
     },
     {
         "id":"chimeric_sam",
         "required":"no",
-        "default":"star_out/Chimeric.out.sam",
         "subst_constructor":{
-                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/Chimeric.out.sam" ],
+                                "vals":[ {"subst":"star_out"}, "Chimeric.out.sam" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
     },
     {
         "id":"readspergene_tab",
         "required":"no",
-        "default":"star_out/ReadsPerGene.out.tab",
         "subst_constructor":{
-                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/ReadsPerGene.out.tab" ],
+                                "vals":[ {"subst":"star_out"}, "ReadsPerGene.out.tab" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
     },
@@ -182,6 +178,11 @@
                                 "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".readspergene.tab" ],
                                 "postproc":{"op":"concat","pad":""}
                             }
+    },
+    {
+        "id":"star_executable",
+        "required":"no",
+        "default":"STAR"
     }
 ],
 "nodes":[
@@ -208,13 +209,13 @@
         "use_STDIN": false,
         "use_STDOUT": true,
         "cmd": [
-                "STAR",
+                {"subst":"star_executable"},
                 "--runMode", "alignReads",
                 "--outFileNamePrefix", {"subst":"star_out"},
                 {"subst":"aligner_numthreads_flag"},
                 "--genomeLoad", "NoSharedMemory",
-                {"subst":"sjdb_annotation_flag"} ,
-                {"subst":"sjdb_overhang_flag"} ,
+                {"subst":"sjdb_annotation_flag"},
+                {"subst":"sjdb_overhang_flag"},
                 "--outSAMstrandField", "intronMotif",
                 "--outSAMattributes", "NH", "HI", "NM", "MD", "AS", "XS",
                 "--outSAMunmapped", "Within", "KeepPairs",

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -1,0 +1,290 @@
+{
+"description":"run star to to align input bam to supplied reference genome",
+"version":"1.0",
+"subgraph_io":{
+    "ports":{
+                "inputs":{
+                            "_stdin_":"bamtofastq",
+                            "reference":"star:__REFERENCE_GENOME_IN__"
+                         },
+                "outputs":{
+                            "_stdout_":"star"
+                          }
+            }
+},
+"subst_params":[
+    {
+        "id": "basic_pipeline_params",
+        "type":"SPFILE",
+        "name":{"subst":"basic_pipeline_params_file"},
+        "required": "no",
+        "comment":"this will expand to a set of subst_param elements"
+    },
+    {
+        "id":"fastq1_name",
+        "required":"no",
+        "default":"intfile_1.fq.gz",
+        "subst_constructor":{
+                                "vals":[ "intfile_1_", {"subst":"rpt"}, ".fq.gz" ],
+                                "postproc":{"op":"concat", "pad":""}
+                            }
+    },
+    {
+        "id":"fastq1",
+        "required":"yes",
+        "subst_constructor":{
+                                "vals":[ {"subst":"tmpdir"}, "/", {"subst":"fastq1_name"} ],
+                                "postproc":{"op":"concat", "pad":""}
+                            }
+    },
+    {
+        "id":"fastq2_name",
+        "required":"no",
+        "default":"intfile_2.fq.gz",
+        "subst_constructor":{
+                                "vals":[ "intfile_2_", {"subst":"rpt"}, ".fq.gz" ],
+                                "postproc":{"op":"concat", "pad":""}
+                            }
+    },
+    {
+        "id":"fastq2",
+        "required":"yes",
+        "subst_constructor":{
+                                "vals":[ {"subst":"tmpdir"}, "/", {"subst":"fastq2_name"} ],
+                                "postproc":{"op":"concat", "pad":""}
+                            }
+    },
+    {
+        "id":"star_dir","required":"no","default":"star_out"
+    },
+    {
+        "id":"star_out",
+        "required":"no",
+        "default": "star_out",
+        "subst_constructor":{
+                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"transcriptome_subpath","required":"no"
+    },
+    {
+        "id":"sjdb_annotation_val",
+        "subst_constructor":{
+                                "vals":[ {"subst":"reposdir"}, "/transcriptomes/", {"subst":"transcriptome_subpath"} ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"sjdb_annotation_flag",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ "--sjdbGTFfile", {"subst":"sjdb_annotation_val"} ],
+                                "postproc":{"op":"concat","pad":" "}
+                            }
+    },
+    {
+        "id":"aligner_numthreads_flag",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ "--runThreadN", {"subst":"aligner_numthreads"} ],
+                                "postproc":{"op":"concat","pad":" "}
+                            }
+    },
+    {
+        "id":"sjdb_overhang_val",
+        "required":"no",
+        "default":"99"
+    },
+    {
+        "id":"sjdb_overhang_flag",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ "--sjdbOverhang", {"subst":"sjdb_overhang_val"} ],
+                                "postproc":{"op":"concat","pad":" "}
+                            }
+    },
+    {
+        "id":"junctions_tab",
+        "required":"no",
+        "default":"star_out/SJ.out.tab",
+        "subst_constructor":{
+                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/SJ.out.tab" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"totranscriptome_bam",
+        "required":"no",
+        "default":"star_out/Aligned.toTranscriptome.out.bam",
+        "subst_constructor":{
+                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/Aligned.toTranscriptome.out.bam" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"chimeric_sam",
+        "required":"no",
+        "default":"star_out/Chimeric.out.sam",
+        "subst_constructor":{
+                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/Chimeric.out.sam" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"readspergene_tab",
+        "required":"no",
+        "default":"star_out/ReadsPerGene.out.tab",
+        "subst_constructor":{
+                                "vals":[ {"subst":"star_dir"}, "_", {"subst":"rpt"}, "/ReadsPerGene.out.tab" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"cp_chimeric_sam_target",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".chimeric.sam" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"cp_totranscriptome_bam_target",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".totranscriptome.bam" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"cp_junctions_tab_target",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".junctions.tab" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
+        "id":"cp_readspergene_tab_target",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".readspergene.tab" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    }
+],
+"nodes":[
+    {
+        "id":"bamtofastq",
+        "type":"EXEC",
+        "use_STDIN": true,
+        "use_STDOUT": false,
+        "cmd":["bamtofastq", "gz=0", "F=__FQ1_OUT__", "F2=__FQ2_OUT__"]
+    },
+    {
+        "id":"fq1",
+        "type":"RAFILE",
+        "name":{"subst":"fastq1"}
+    },
+    {
+        "id":"fq2",
+        "type":"RAFILE",
+        "name":{"subst":"fastq2"}
+    },
+    {
+        "id":"star",
+        "type":"EXEC",
+        "use_STDIN": false,
+        "use_STDOUT": true,
+        "cmd": [
+                "STAR",
+                "--runMode", "alignReads",
+                "--outFileNamePrefix", {"subst":"star_out"},
+                {"subst":"aligner_numthreads_flag"},
+                "--genomeLoad", "NoSharedMemory",
+                {"subst":"sjdb_annotation_flag"} ,
+                {"subst":"sjdb_overhang_flag"} ,
+                "--outSAMstrandField", "intronMotif",
+                "--outSAMattributes", "NH", "HI", "NM", "MD", "AS", "XS",
+                "--outSAMunmapped", "Within", "KeepPairs",
+                "--outSAMtype", "BAM", "Unsorted",
+                "--outFilterIntronMotifs", "RemoveNoncanonicalUnannotated",
+                "--chimOutType", "SeparateSAMold",
+                "--chimSegmentMin", "15",
+                "--chimJunctionOverhangMin", "15",
+                "--quantMode", "TranscriptomeSAM", "GeneCounts",
+                "--genomeDir", "__REFERENCE_GENOME_IN__",
+                "--readFilesIn", "__FQ1_IN__", "__FQ2_IN__",
+                "--outStd", "BAM_Unsorted"
+        ]
+    },
+    {
+        "id":"junctions_tab",
+        "type":"RAFILE",
+        "subtype":"DUMMY",
+        "name":{"subst":"junctions_tab"}
+    },
+    {
+        "id":"totranscriptome_bam",
+        "type":"RAFILE",
+        "subtype":"DUMMY",
+        "name":{"subst":"totranscriptome_bam"}
+    },
+    {
+        "id":"chimeric_sam",
+        "type":"RAFILE",
+        "subtype":"DUMMY",
+        "name":{"subst":"chimeric_sam"}
+    },
+    {
+        "id":"readspergene_tab",
+        "type":"RAFILE",
+        "subtype":"DUMMY",
+        "name":{"subst":"readspergene_tab"}
+    },
+    {
+        "id":"cp_chimeric_sam",
+        "type":"EXEC",
+        "use_STDIN": false,
+        "use_STDOUT": false,
+        "cmd":[ "cp", "__SRC_CHIMERIC_SAM_IN__", {"subst":"cp_chimeric_sam_target"} ]
+    },
+    {
+        "id":"cp_totranscriptome_bam",
+        "type":"EXEC",
+        "use_STDIN": false,
+        "use_STDOUT": false,
+        "cmd":[ "cp", "__SRC_TOTRANSCRIPTOME_BAM_IN__", {"subst":"cp_totranscriptome_bam_target"} ]
+    },
+    {
+        "id":"cp_junctions_tab",
+        "type":"EXEC",
+        "use_STDIN": false,
+        "use_STDOUT": false,
+        "cmd":[ "cp", "__SRC_JUNCTIONS_TAB_IN__", {"subst":"cp_junctions_tab_target"} ]
+    },
+    {
+        "id":"cp_readspergene_tab",
+        "type":"EXEC",
+        "use_STDIN": false,
+        "use_STDOUT": false,
+        "cmd":[ "cp", "__SRC_READSPERGENE_TAB_IN__", {"subst":"cp_readspergene_tab_target"} ]
+    }
+],
+"edges":[
+    { "id":"bamtofastq_to_fq1", "from":"bamtofastq:__FQ1_OUT__", "to":"fq1" },
+    { "id":"bamtofastq_to_fq2", "from":"bamtofastq:__FQ2_OUT__", "to":"fq2" },
+    { "id":"fq1_to_star", "from":"fq1", "to":"star:__FQ1_IN__" },
+    { "id":"fq2_to_star", "from":"fq2", "to":"star:__FQ2_IN__" },
+    { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
+    { "id":"star_to_chimeric_sam", "from":"star", "to":"chimeric_sam" },
+    { "id":"cp_chimeric_sam", "from":"chimeric_sam", "to":"cp_chimeric_sam:__SRC_CHIMERIC_SAM_IN__" },
+    { "id":"star_to_totranscriptome_bam", "from":"star", "to":"totranscriptome_bam" },
+    { "id":"cp_totranscriptome_bam", "from":"totranscriptome_bam", "to":"cp_totranscriptome_bam:__SRC_TOTRANSCRIPTOME_BAM_IN__" },
+    { "id":"star_to_junctions_tab", "from":"star", "to":"junctions_tab" },
+    { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:__SRC_JUNCTIONS_TAB_IN__" },
+    { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
+    { "id":"cp_readspergene_tab", "from":"readspergene_tab", "to":"cp_readspergene_tab:__SRC_READSPERGENE_TAB_IN__" }
+]
+}

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -110,63 +110,11 @@
                             }
     },
     {
-        "id":"totranscriptome_bam",
-        "required":"no",
-        "subst_constructor":{
-                                "vals":[ {"subst":"star_out"}, "Aligned.toTranscriptome.out.bam" ],
-                                "postproc":{"op":"concat","pad":""}
-                            }
-    },
-    {
-        "id":"chimeric_sam",
-        "required":"no",
-        "subst_constructor":{
-                                "vals":[ {"subst":"star_out"}, "Chimeric.out.sam" ],
-                                "postproc":{"op":"concat","pad":""}
-                            }
-    },
-    {
         "id":"readspergene_tab",
         "required":"no",
         "subst_constructor":{
                                 "vals":[ {"subst":"star_out"}, "ReadsPerGene.out.tab" ],
                                 "postproc":{"op":"concat","pad":""}
-                            }
-    },
-    {
-        "id":"scramble_chimeric_sam_target",
-        "required":"no",
-        "subst_constructor":{
-                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".chimeric.cram" ],
-                                "postproc":{"op":"concat","pad":""}
-                            }
-    },
-    {
-        "id":"scramble_totranscriptome_bam_target",
-        "required":"no",
-        "subst_constructor":{
-                                "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".totranscriptome.cram" ],
-                                "postproc":{"op":"concat","pad":""}
-                            }
-    },
-    {
-        "id":"reference_genome_fasta_name","required":"no"},
-    {
-        "id":"reference_genome_fasta",
-        "required":"yes",
-        "subst_constructor":{
-                                "vals":[ {"subst":"reposdir"}, "/", {"subst":"reference_genome_fasta_name"} ],
-                                "postproc":{"op":"concat", "pad":""}
-                            }
-    },
-    {
-        "id":"reference_transcriptome_fasta_name","required":"no"},
-    {
-        "id":"reference_transcriptome_fasta",
-        "required":"yes",
-        "subst_constructor":{
-                                "vals":[ {"subst":"reposdir"}, "/", {"subst":"reference_transcriptome_fasta_name"} ],
-                                "postproc":{"op":"concat", "pad":""}
                             }
     },
     {
@@ -235,10 +183,10 @@
                 "--outSAMunmapped", "Within", "KeepPairs",
                 "--outSAMtype", "BAM", "Unsorted",
                 "--outFilterIntronMotifs", "RemoveNoncanonicalUnannotated",
-                "--chimOutType", "SeparateSAMold",
+                "--chimOutType", "WithinBAM",
                 "--chimSegmentMin", "15",
                 "--chimJunctionOverhangMin", "15",
-                "--quantMode", "TranscriptomeSAM", "GeneCounts",
+                "--quantMode", "GeneCounts",
                 "--genomeDir", "__REFERENCE_GENOME_IN__",
                 "--readFilesIn", "__FQ1_IN__", "__FQ2_IN__",
                 "--outStd", "BAM_Unsorted"
@@ -251,56 +199,10 @@
         "name":{"subst":"junctions_tab"}
     },
     {
-        "id":"totranscriptome_bam",
-        "type":"RAFILE",
-        "subtype":"DUMMY",
-        "name":{"subst":"totranscriptome_bam"}
-    },
-    {
-        "id":"chimeric_sam",
-        "type":"RAFILE",
-        "subtype":"DUMMY",
-        "name":{"subst":"chimeric_sam"}
-    },
-    {
         "id":"readspergene_tab",
         "type":"RAFILE",
         "subtype":"DUMMY",
         "name":{"subst":"readspergene_tab"}
-    },
-    {
-        "id":"scramble_chimeric_sam",
-        "type":"EXEC",
-        "use_STDIN": false,
-        "use_STDOUT": false,
-        "cmd":[
-                "scramble",
-                {"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-t", {"subst":"b2c_mt_val"} ]}}},
-                {"subst":"b2c_fmtver", "ifnull":{"subst_constructor":{ "vals":[ "-V", {"subst":"b2c_format_version"} ]}}},
-                {"subst":"b2c_compress_level", "ifnull":"-7"},
-                "-I", "sam",
-                "-O", "cram",
-                 "-r", {"subst":"reference_genome_fasta"},
-                "__SRC_CHIMERIC_SAM_IN__",
-                {"subst":"scramble_chimeric_sam_target"}
-        ]
-    },
-    {
-        "id":"scramble_totranscriptome_bam",
-        "type":"EXEC",
-        "use_STDIN": false,
-        "use_STDOUT": false,
-        "cmd":[
-                "scramble",
-                {"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-t", {"subst":"b2c_mt_val"} ]}}},
-                {"subst":"b2c_fmtver", "ifnull":{"subst_constructor":{ "vals":[ "-V", {"subst":"b2c_format_version"} ]}}},
-                {"subst":"b2c_compress_level", "ifnull":"-7"},
-                "-I", "bam",
-                "-O", "cram",
-                "-r", {"subst":"reference_transcriptome_fasta"},
-                "__SRC_TOTRANSCRIPTOME_BAM_IN__",
-                {"subst":"scramble_totranscriptome_bam_target"}
-        ]
     },
     {
         "id":"cp_junctions_tab",
@@ -332,10 +234,6 @@
     { "id":"bamtofastq_to_fq2", "from":"bamtofastq:__FQ2_OUT__", "to":"fq2" },
     { "id":"fq1_to_star", "from":"fq1", "to":"star:__FQ1_IN__" },
     { "id":"fq2_to_star", "from":"fq2", "to":"star:__FQ2_IN__" },
-    { "id":"star_to_chimeric_sam", "from":"star", "to":"chimeric_sam" },
-    { "id":"scramble_chimeric_sam", "from":"chimeric_sam", "to":"scramble_chimeric_sam:__SRC_CHIMERIC_SAM_IN__"},
-    { "id":"star_to_totranscriptome_bam", "from":"star", "to":"totranscriptome_bam" },
-    { "id":"scramble_totranscriptome_bam", "from":"totranscriptome_bam", "to":"scramble_totranscriptome_bam:__SRC_TOTRANSCRIPTOME_BAM_IN__" },
     { "id":"star_to_junctions_tab", "from":"star", "to":"junctions_tab" },
     { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:__SRC_JUNCTIONS_TAB_IN__" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -150,9 +150,9 @@
                             }
     },
     {
-        "id":"scramble_genome_reference_flag",
+        "id":"scramble_chimeric_reference_flag",
         "required":"no",
-        "subst_constructor":{ "vals":[ "-r", {"subst":"reference_genome_fasta"} ] }
+        "subst_constructor":{ "vals":[ "-r", {"subst":"scramble_reference_fasta"} ] }
     },
     {
         "id":"scramble_transcriptome_reference_flag",
@@ -270,7 +270,7 @@
                 {"subst":"b2c_compress_level", "ifnull":"-7"},
                 "-I", "sam",
                 "-O", "cram",
-                {"subst":"scramble_genome_reference_flag"},
+                {"subst":"scramble_chimeric_reference_flag"},
                 "__SRC_CHIMERIC_SAM_IN__",
                 {"subst":"scramble_chimeric_sam_target"}
         ]
@@ -322,7 +322,6 @@
     { "id":"bamtofastq_to_fq2", "from":"bamtofastq:__FQ2_OUT__", "to":"fq2" },
     { "id":"fq1_to_star", "from":"fq1", "to":"star:__FQ1_IN__" },
     { "id":"fq2_to_star", "from":"fq2", "to":"star:__FQ2_IN__" },
-    { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
     { "id":"star_to_chimeric_sam", "from":"star", "to":"chimeric_sam" },
     { "id":"scramble_chimeric_sam", "from":"chimeric_sam", "to":"scramble_chimeric_sam:__SRC_CHIMERIC_SAM_IN__"},
     { "id":"star_to_totranscriptome_bam", "from":"star", "to":"totranscriptome_bam" },
@@ -331,7 +330,7 @@
     { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:__SRC_JUNCTIONS_TAB_IN__" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
     { "id":"cp_readspergene_tab", "from":"readspergene_tab", "to":"cp_readspergene_tab:__SRC_READSPERGENE_TAB_IN__" },
-	{ "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fq1" },
-	{ "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fq2" }
+    { "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fastq1" },
+    { "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2" }
 ]
 }

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -150,14 +150,24 @@
                             }
     },
     {
-        "id":"scramble_chimeric_reference_flag",
-        "required":"no",
-        "subst_constructor":{ "vals":[ "-r", {"subst":"scramble_reference_fasta"} ] }
+        "id":"reference_genome_fasta_name","required":"no"},
+    {
+        "id":"reference_genome_fasta",
+        "required":"yes",
+        "subst_constructor":{
+                                "vals":[ {"subst":"reposdir"}, "/", {"subst":"reference_genome_fasta_name"} ],
+                                "postproc":{"op":"concat", "pad":""}
+                            }
     },
     {
-        "id":"scramble_transcriptome_reference_flag",
-        "required":"no",
-        "subst_constructor":{ "vals":[ "-r", {"subst":"reference_transcriptome_fasta"} ] }
+        "id":"reference_transcriptome_fasta_name","required":"no"},
+    {
+        "id":"reference_transcriptome_fasta",
+        "required":"yes",
+        "subst_constructor":{
+                                "vals":[ {"subst":"reposdir"}, "/", {"subst":"reference_transcriptome_fasta_name"} ],
+                                "postproc":{"op":"concat", "pad":""}
+                            }
     },
     {
         "id":"cp_junctions_tab_target",
@@ -270,7 +280,7 @@
                 {"subst":"b2c_compress_level", "ifnull":"-7"},
                 "-I", "sam",
                 "-O", "cram",
-                {"subst":"scramble_chimeric_reference_flag"},
+                 "-r", {"subst":"reference_genome_fasta"},
                 "__SRC_CHIMERIC_SAM_IN__",
                 {"subst":"scramble_chimeric_sam_target"}
         ]
@@ -287,7 +297,7 @@
                 {"subst":"b2c_compress_level", "ifnull":"-7"},
                 "-I", "bam",
                 "-O", "cram",
-                {"subst":"scramble_transcriptome_reference_flag"},
+                "-r", {"subst":"reference_transcriptome_fasta"},
                 "__SRC_TOTRANSCRIPTOME_BAM_IN__",
                 {"subst":"scramble_totranscriptome_bam_target"}
         ]

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -66,11 +66,7 @@
                             }
     },
     {
-        "id":"transcriptome_subpath",
-        "required":"no"
-    },
-    {
-        "id":"sjdb_annotation_val",
+        "id":"annotation_val",
         "subst_constructor":{
                                 "vals":[ {"subst":"reposdir"}, "/transcriptomes/", {"subst":"transcriptome_subpath"} ],
                                 "postproc":{"op":"concat","pad":""}
@@ -80,7 +76,7 @@
         "id":"sjdb_annotation_flag",
         "required":"no",
         "subst_constructor":{
-                                "vals":[ "--sjdbGTFfile", {"subst":"sjdb_annotation_val"} ],
+                                "vals":[ "--sjdbGTFfile", {"subst":"annotation_val"} ],
                                 "postproc":{"op":"concat","pad":" "}
                             }
     },
@@ -183,6 +179,64 @@
         "id":"star_executable",
         "required":"no",
         "default":"STAR"
+    },
+    {
+        "id":"salmon_dir",
+        "required":"no",
+        "default":"salmon_quant"
+    },
+    {
+        "id":"salmon_out",
+        "required":"no",
+        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"} ], "postproc":{"op":"concat","pad":""} }
+    },
+    {
+        "id":"salmon_quant",
+        "required":"no",
+        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/quant.sf" ], "postproc":{"op":"concat","pad":""} },
+        "default":"salmon_quant/quant.sf"
+    },
+    {
+        "id":"salmon_quant_genes",
+        "required":"no",
+        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/quant.genes.sf" ], "postproc":{"op":"concat","pad":""} },
+        "default":"salmon_quant/quant.genes.sf"
+    },
+    {
+        "id":"salmon_lib_format_counts",
+        "required":"no",
+        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/lib_format_counts.json" ], "postproc":{"op":"concat","pad":""} },
+        "default":"salmon_quant/lib_format_counts.json"
+    },
+    {
+        "id":"salmon_libparams",
+        "required":"no",
+        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/libParams" ], "postproc":{"op":"concat","pad":""} },
+        "default":"salmon_quant/libParams"
+    },
+    {
+        "id":"salmon_cmd_info",
+        "required":"no",
+        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/cmd_info.json" ], "postproc":{"op":"concat","pad":""} },
+        "default":"salmon_quant/cmd_info.json"
+    },
+    {
+        "id":"zip_salmon_quant_target",
+        "required":"no",
+        "subst_constructor":{ "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".salmon_quant.zip" ], "postproc":{"op":"concat","pad":""} }
+    },
+    {
+        "id":"transcriptome_subpath",
+        "required":"no"
+    },
+    {
+        "id":"transcriptome_val",
+        "subst_constructor":{ "vals":[ {"subst":"reposdir"}, "/transcriptomes/", {"subst":"transcriptome_subpath"} ], "postproc":{"op":"concat","pad":""} }
+    },
+    {
+        "id":"gene_mapping_flag",
+        "required":"no",
+        "subst_constructor":{ "vals":[ "--geneMap=", {"subst":"annotation_val"} ], "postproc":{"op":"concat","pad":""} }
     }
 ],
 "nodes":[
@@ -301,6 +355,39 @@
         "use_STDIN": false,
         "use_STDOUT": false,
         "cmd":[ "cp", "__SRC_READSPERGENE_TAB_IN__", {"subst":"cp_readspergene_tab_target"} ]
+    },
+    {
+        "id":"salmon",
+        "type":"EXEC",
+        "use_STDIN": false,
+        "use_STDOUT": true,
+        "cmd":[
+                "salmon",
+                "--no-version-check",
+                "quant",
+                "--index", {"subst":"transcriptome_val"},
+                "--libType", "A",
+                "--mates1", "__FQ1_IN__",
+                "--mates2", "__FQ2_IN__",
+                {"subst":"gene_mapping_flag"},
+                {"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-p", {"subst":"b2c_mt_val"} ]}}},
+                "--output", {"subst":"salmon_out"}
+        ]
+    },
+    {
+        "id":"zip_salmon_quant",
+        "type":"EXEC",
+        "use_STDIN": true,
+        "use_STDOUT": false,
+        "cmd":[ 
+                "zip", "-r",
+                {"subst":"zip_salmon_quant_target"},
+                {"subst":"salmon_quant"},
+                {"subst":"salmon_quant_genes"},
+                {"subst":"salmon_lib_format_counts"},
+                {"subst":"salmon_libparams"},
+                {"subst":"salmon_cmd_info"}
+              ]
     }
 ],
 "edges":[
@@ -316,6 +403,9 @@
     { "id":"star_to_junctions_tab", "from":"star", "to":"junctions_tab" },
     { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:__SRC_JUNCTIONS_TAB_IN__" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
-    { "id":"cp_readspergene_tab", "from":"readspergene_tab", "to":"cp_readspergene_tab:__SRC_READSPERGENE_TAB_IN__" }
+    { "id":"cp_readspergene_tab", "from":"readspergene_tab", "to":"cp_readspergene_tab:__SRC_READSPERGENE_TAB_IN__" },
+    { "id":"fq1_to_salmon", "from":"fq1", "to":"salmon:__FQ1_IN__" },
+    { "id":"fq2_to_salmon", "from":"fq2", "to":"salmon:__FQ2_IN__" },
+    { "id":"salmon_to_zip_salmon_quant", "from":"salmon", "to":"zip_salmon_quant"}
 ]
 }

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -181,62 +181,12 @@
         "default":"STAR"
     },
     {
-        "id":"salmon_dir",
-        "required":"no",
-        "default":"salmon_quant"
-    },
-    {
-        "id":"salmon_out",
-        "required":"no",
-        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"} ], "postproc":{"op":"concat","pad":""} }
-    },
-    {
-        "id":"salmon_quant",
-        "required":"no",
-        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/quant.sf" ], "postproc":{"op":"concat","pad":""} },
-        "default":"salmon_quant/quant.sf"
-    },
-    {
-        "id":"salmon_quant_genes",
-        "required":"no",
-        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/quant.genes.sf" ], "postproc":{"op":"concat","pad":""} },
-        "default":"salmon_quant/quant.genes.sf"
-    },
-    {
-        "id":"salmon_lib_format_counts",
-        "required":"no",
-        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/lib_format_counts.json" ], "postproc":{"op":"concat","pad":""} },
-        "default":"salmon_quant/lib_format_counts.json"
-    },
-    {
-        "id":"salmon_libparams",
-        "required":"no",
-        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/libParams" ], "postproc":{"op":"concat","pad":""} },
-        "default":"salmon_quant/libParams"
-    },
-    {
-        "id":"salmon_cmd_info",
-        "required":"no",
-        "subst_constructor":{ "vals":[ {"subst":"salmon_dir"}, "_", {"subst":"rpt"}, "/cmd_info.json" ], "postproc":{"op":"concat","pad":""} },
-        "default":"salmon_quant/cmd_info.json"
-    },
-    {
-        "id":"zip_salmon_quant_target",
-        "required":"no",
-        "subst_constructor":{ "vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".salmon_quant.zip" ], "postproc":{"op":"concat","pad":""} }
-    },
-    {
-        "id":"transcriptome_subpath",
-        "required":"no"
-    },
-    {
-        "id":"transcriptome_val",
-        "subst_constructor":{ "vals":[ {"subst":"reposdir"}, "/transcriptomes/", {"subst":"transcriptome_subpath"} ], "postproc":{"op":"concat","pad":""} }
-    },
-    {
-        "id":"gene_mapping_flag",
-        "required":"no",
-        "subst_constructor":{ "vals":[ "--geneMap=", {"subst":"annotation_val"} ], "postproc":{"op":"concat","pad":""} }
+        "id":"quant_vtf",
+        "required":"yes",
+        "subst_constructor":{
+                                "vals":[ {"subst":"cfgdatadir"}, "/", {"subst":"quant_method"}, "_alignment.json" ],
+                                "postproc":{"op":"concat", "pad":""}
+                            }
     }
 ],
 "nodes":[
@@ -357,37 +307,14 @@
         "cmd":[ "cp", "__SRC_READSPERGENE_TAB_IN__", {"subst":"cp_readspergene_tab_target"} ]
     },
     {
-        "id":"salmon",
-        "type":"EXEC",
+        "id":"quantify",
+        "type":"VTFILE",
         "use_STDIN": false,
         "use_STDOUT": true,
-        "cmd":[
-                "salmon",
-                "--no-version-check",
-                "quant",
-                "--index", {"subst":"transcriptome_val"},
-                "--libType", "A",
-                "--mates1", "__FQ1_IN__",
-                "--mates2", "__FQ2_IN__",
-                {"subst":"gene_mapping_flag"},
-                {"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-p", {"subst":"b2c_mt_val"} ]}}},
-                "--output", {"subst":"salmon_out"}
-        ]
-    },
-    {
-        "id":"zip_salmon_quant",
-        "type":"EXEC",
-        "use_STDIN": true,
-        "use_STDOUT": false,
-        "cmd":[ 
-                "zip", "-r",
-                {"subst":"zip_salmon_quant_target"},
-                {"subst":"salmon_quant"},
-                {"subst":"salmon_quant_genes"},
-                {"subst":"salmon_lib_format_counts"},
-                {"subst":"salmon_libparams"},
-                {"subst":"salmon_cmd_info"}
-              ]
+        "comment":"inputs: fq1, fq2; outputs: NONE",
+        "node_prefix":"quant_",
+        "name":{"subst":"quant_vtf"},
+        "description":"subgraph containing salmon quantification of transcripts"
     }
 ],
 "edges":[
@@ -404,8 +331,7 @@
     { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:__SRC_JUNCTIONS_TAB_IN__" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
     { "id":"cp_readspergene_tab", "from":"readspergene_tab", "to":"cp_readspergene_tab:__SRC_READSPERGENE_TAB_IN__" },
-    { "id":"fq1_to_salmon", "from":"fq1", "to":"salmon:__FQ1_IN__" },
-    { "id":"fq2_to_salmon", "from":"fq2", "to":"salmon:__FQ2_IN__" },
-    { "id":"salmon_to_zip_salmon_quant", "from":"salmon", "to":"zip_salmon_quant"}
+	{ "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fq1" },
+	{ "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fq2" }
 ]
 }

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -107,7 +107,7 @@
         "subst_constructor":{
                                 "vals":[ "--chimSegmentMin", {
                                                                  "subst":"chimSegmentMin_val",
-                                                                 "inull":"0",
+                                                                 "ifnull":"0",
                                                                  "comment":"unset this value to remove --chimSegmentMin flag"
                                                              }
                                 ],

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -102,6 +102,32 @@
                             }
     },
     {
+        "id":"chimSegmentMin_flag",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ "--chimSegmentMin", {
+                                                                 "subst":"chimSegmentMin_val",
+                                                                 "inull":"0",
+                                                                 "comment":"unset this value to remove --chimSegmentMin flag"
+                                                             }
+                                ],
+                                "postproc":{"op":"concat","pad":" "}
+                            }
+    },
+    {
+        "id":"chimJunctionOverhangMin_flag",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ "--chimJunctionOverhangMin", {
+                                                                          "subst":"chimJunctionOverhangMin_val", 
+                                                                          "ifnull":"20",
+                                                                          "comment":"unset this value to remove --chimJunctionOverhangMin flag"
+                                                                      }
+                                ],
+                                "postproc":{"op":"concat","pad":" "}
+                            }
+    },
+    {
         "id":"junctions_tab",
         "required":"no",
         "subst_constructor":{
@@ -184,8 +210,8 @@
                 "--outSAMtype", "BAM", "Unsorted",
                 "--outFilterIntronMotifs", "RemoveNoncanonicalUnannotated",
                 "--chimOutType", "WithinBAM",
-                "--chimSegmentMin", "15",
-                "--chimJunctionOverhangMin", "15",
+                {"subst":"chimSegmentMin_flag"},
+                {"subst":"chimJunctionOverhangMin_flag"},
                 "--quantMode", "GeneCounts",
                 "--genomeDir", "__REFERENCE_GENOME_IN__",
                 "--readFilesIn", "__FQ1_IN__", "__FQ2_IN__",


### PR DESCRIPTION
- New template json file for STAR alignment.
- Connects upstream and downstream seamlessly just as the template for Tophat2 alignment does.
- The biggest external requirement is the need of reference transcriptome files in FASTA format.
- Some keys are specific to it but nothing major; others are akin to those of tophat's but with different names that make more sense for STAR.
- Tried and tested with no issues.
- Would benefit from liaising with customers to dertermine if some of the outputs are surplus to requirement or others are needed; as well as for fine tuning alignment options.