### PR TITLE
tiny change in naming for zip file of compressed outputs

### DIFF
--- a/data/vtlib/salmon_alignment.json
+++ b/data/vtlib/salmon_alignment.json
@@ -72,7 +72,7 @@
 		"id":"zip_target",
 		"required":"no",
 		"subst_constructor":{
-			"vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".salmon_quant.zip" ],
+			"vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, "_salmon.quant.zip" ],
 			"postproc":{"op":"concat","pad":""}
 		}
 	},


### PR DESCRIPTION
tiny last minute change to comply with current naming conventions as well as for future-proofing