### PR TITLE
Change access permissions for residual directory created by STAR

### DIFF
--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -144,6 +144,14 @@
                             }
     },
     {
+        "id":"STARgenome_dir",
+        "required":"no",
+        "subst_constructor":{
+                                "vals":[ {"subst":"star_out"}, "_STARgenome" ],
+                                "postproc":{"op":"concat","pad":""}
+                            }
+    },
+    {
         "id":"cp_junctions_tab_target",
         "required":"no",
         "subst_constructor":{
@@ -231,6 +239,12 @@
         "name":{"subst":"readspergene_tab"}
     },
     {
+        "id":"STARgenome_dir",
+        "type":"RAFILE",
+        "subtype":"DUMMY",
+        "name":{"subst":"STARgenome_dir"}
+    },
+    {
         "id":"cp_junctions_tab",
         "type":"EXEC",
         "use_STDIN": false,
@@ -243,6 +257,14 @@
         "use_STDIN": false,
         "use_STDOUT": false,
         "cmd":[ "cp", "__SRC_READSPERGENE_TAB_IN__", {"subst":"cp_readspergene_tab_target"} ]
+    },
+    {
+        "id":"chmod_STARgenome_dir",
+        "type":"EXEC",
+        "use_STDIN": false,
+        "use_STDOUT": false,
+        "cmd":[ "chmod", "-R", "g+w", "__SRC_STARGENOME_DIR_IN__" ],
+        "comment":"This is necessary because STAR creates this transitional directory as group-read-only and cannot be deleted later"
     },
     {
         "id":"quantify",
@@ -264,6 +286,8 @@
     { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:__SRC_JUNCTIONS_TAB_IN__" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
     { "id":"cp_readspergene_tab", "from":"readspergene_tab", "to":"cp_readspergene_tab:__SRC_READSPERGENE_TAB_IN__" },
+    { "id":"star_to_stargenome_dir", "from":"star", "to":"STARgenome_dir" },
+    { "id":"chmod_stargenome_dir", "from":"STARgenome_dir", "to":"chmod_STARgenome_dir:__SRC_STARGENOME_DIR_IN__" },
     { "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fastq1" },
     { "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2" }
 ]


### PR DESCRIPTION
... so it can be deleted later.

- Add RAFILE dummy for directory STARgenome, created by STAR as
  group-read-only thus making it impossible to remove by other
  users as required in some circumstances, like reanalyses.
- Add EXEC node for chmod command.