### PR TITLE
Star fixes

### DIFF
--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -8,7 +8,7 @@
                             "reference":"star:reference_genome"
                          },
                 "outputs":{
-                            "_stdout_":"star"
+                            "_stdout_":"bamsort_qname"
                           }
             }
 },
@@ -227,6 +227,13 @@
         ]
     },
     {
+        "id":"bamsort_qname",
+        "type":"EXEC",
+        "use_STDIN": true,
+        "use_STDOUT": true,
+        "cmd":["bamsormadup", {"subst":"bsmd_threads"},"SO=queryname", "level=0"]
+    },
+    {
         "id":"junctions_tab",
         "type":"RAFILE",
         "subtype":"DUMMY",
@@ -289,6 +296,7 @@
     { "id":"star_to_stargenome_dir", "from":"star", "to":"STARgenome_dir" },
     { "id":"chmod_stargenome_dir", "from":"STARgenome_dir", "to":"chmod_STARgenome_dir:src_stargenome_dir" },
     { "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fastq1" },
-    { "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2" }
+    { "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2" },
+    { "id":"star_to_qname_sort", "from":"star", "to":"bamsort_qname" }
 ]
 }

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -1,6 +1,6 @@
 {
 "description":"run star to to align input bam to supplied reference genome",
-"version":"1.0",
+"version":"2.0",
 "subgraph_io":{
     "ports":{
                 "inputs":{

--- a/data/vtlib/target_alignment.json
+++ b/data/vtlib/target_alignment.json
@@ -44,7 +44,7 @@
 		"id":"tee3",
 		"type":"VTFILE",
 		"node_prefix":"tee3_",
-		"name":{"select":"align_infile_opt", "default":0, "select_range":[0,1],
+		"name":{"select":"align_intfile_opt", "default":0, "select_range":[0,1],
 				"cases":[
 					"unaln_tee3.json",
 					"unaln_intfile.json"


### PR DESCRIPTION
star_alignment template: update version, add queryname sort after alignment, change parameter name to "align_intfile_opt"

viv.pl: loosen validity check of connection types (overly strict for output file nodes of subtype DUMMY)