### PR TITLE
flag change for use with tears 1.2.4

### DIFF
--- a/data/vtlib/merge_final_output_prep.json
+++ b/data/vtlib/merge_final_output_prep.json
@@ -231,7 +231,7 @@
 	"type":"EXEC",
 	"use_STDIN": true,
 	"use_STDOUT": false,
-	"cmd": [ "tears", {"subst":"cram_file"} ],
+	"cmd": [ "tears", "-w", "-f", {"subst":"cram_file", "required":true} ],
 	"comment":"stream into iRODS"
     },
     { "id":"cram_md5", "type":"OUTFILE", "name":{"subst":"cram_md5"} },


### PR DESCRIPTION
If existing cram file found it would be overwritten rather than fail