### PR TITLE
Assign appropriate suffixes to bamtofastq output files for STAR align template

### DIFF
--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -23,9 +23,9 @@
     {
         "id":"fastq1_name",
         "required":"no",
-        "default":"intfile_1.fq.gz",
+        "default":"intfile_1.fq",
         "subst_constructor":{
-                                "vals":[ "intfile_1_", {"subst":"rpt"}, ".fq.gz" ],
+                                "vals":[ "intfile_1_", {"subst":"rpt"}, ".fq" ],
                                 "postproc":{"op":"concat", "pad":""}
                             }
     },
@@ -40,9 +40,9 @@
     {
         "id":"fastq2_name",
         "required":"no",
-        "default":"intfile_2.fq.gz",
+        "default":"intfile_2.fq",
         "subst_constructor":{
-                                "vals":[ "intfile_2_", {"subst":"rpt"}, ".fq.gz" ],
+                                "vals":[ "intfile_2_", {"subst":"rpt"}, ".fq" ],
                                 "postproc":{"op":"concat", "pad":""}
                             }
     },


### PR DESCRIPTION
Use suffix .fq instead of .fq.gz because bamtofastq has option gz=0 which means they are not being compressed - this is OK and necessary for STAR