### PR TITLE
Support single-end libraries and wrap salmon command for validation and clean exiting

### DIFF
--- a/data/vtlib/salmon_alignment.json
+++ b/data/vtlib/salmon_alignment.json
@@ -77,19 +77,7 @@
 		}
 	},
 	{
-		"id":"gene_mapping_flag",
-		"required":"no",
-		"subst_constructor":{
-			"vals":[ "--geneMap=", {"subst":"annotation_val"} ],
-			"postproc":{"op":"concat","pad":""}
-		}
-	},
-	{
-		"id":"salmon_transcriptome_val",
-		"required":"yes"
-	},
-	{
-		"id":"cp_quant_genes_target",
+		"id":"quant_genes_target",
 		"required":"no",
 		"subst_constructor":{
 			"vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".quant.genes.sf" ],
@@ -101,35 +89,45 @@
 	{
 		"id":"salmon",
 		"type":"EXEC",
+		"subtype":"STRINGIFY",
 		"use_STDIN": false,
 		"use_STDOUT": true,
 		"cmd":[
-				"salmon",
-				"--no-version-check",
-				"quant",
-				"--index", {"subst":"salmon_transcriptome_val"},
-				"--libType", "A",
-				"--mates1", {"port":"fq1", "direction":"in"},
-				"--mates2", {"port":"fq2", "direction":"in"},
-				{"subst":"gene_mapping_flag"},
-				{"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-p", {"subst":"b2c_mt_val"} ]}}},
-				"--output", {"subst":"salmon_out"}
-		]
+				"bash -c '",
+					"SALMON_CMD=\"salmon --no-version-check quant --libType A",
+					"--index", {"subst":"salmon_transcriptome_val", "required":"yes"},
+					"--geneMap", {"subst":"annotation_val", "required":"yes"},
+					"--output", {"subst":"salmon_out"},
+					{"subst":"b2c_mt", "ifnull":{"subst_constructor":{ "vals":[ "-p", {"subst":"b2c_mt_val"} ]}}}, "\";",
+					"case `file $0` in *ASCII*) PART1=`head -c 50K $0 | wc -l`;; *compressed*) PART1=`gunzip -c $0 | head -c 50K | wc -l`;; *empty*) PART1=0;; esac;",
+					"if [[ $0 && ! $1 ]]; then",
+						"SALMON_CMD+=\"-r $0\";",
+						"if [[ $PART1 -lt 1000 ]]; then",
+							">&2 printf \"Not enough reads to run Salmon: fq: %s\" \"$((PART1/4))\"; exit 0; fi;",
+					"elif [[ $0 && $1 ]]; then",
+						"SALMON_CMD+=\"-1 $0 -2 $1\";",
+						"case `file $1` in *ASCII*) PART2=`head -c 50K $1 | wc -l`;; *compressed*) PART2=`gunzip -c $1 | head -c 50K | wc -l`;; *empty*) PART2=0;; esac;",
+						"if [[ $PART1 -lt 1000 || $PART2 -lt 1000 ]]; then",
+							">&2 printf \"Not enough reads to run Salmon: fq1: %s - fq2: %s\" \"$((PART1/4))\" \"$((PART2/4))\"; exit 0; fi; fi;",
+					"$SALMON_CMD'",
+					{
+						"select":"alignment_reads_layout",
+						"default":"2",
+						"select_range":[1],
+						"cases":{
+							"1":[{"port":"fq1", "direction":"in"}],
+							"2":[{"port":"fq1", "direction":"in"}, {"port":"fq2", "direction":"in"}]
+						}
+					}
+		],
+		"comment":"salmon is too fussy and requires a minimum of good reads to work or it throws a fit. wrapped in a bash script to validate fastq files"
 	},
 	{
 		"id":"zip_salmon_quant",
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": false,
-		"cmd":[ 
-				"zip", "-r",
-				{"subst":"zip_target"},
-				{"subst":"quant"},
-				{"subst":"quant_genes"},
-				{"subst":"lib_format_counts"},
-				{"subst":"libparams"},
-				{"subst":"cmd_info"}
-			  ]
+		"cmd":[ "zip", "-r", {"subst":"zip_target"}, {"subst":"quant"}, {"subst":"quant_genes"}, {"subst":"lib_format_counts"}, {"subst":"libparams"}, {"subst":"cmd_info"} ]
 	},
 	{
 		"id":"quant_genes",
@@ -140,13 +138,17 @@
 	{
 		"id":"cp_quant_genes",
 		"type":"EXEC",
+		"subtype":"STRINGIFY",
 		"use_STDIN": false,
 		"use_STDOUT": false,
-		"cmd":[ "cp", {"port":"src_quant_genes", "direction":"in"}, {"subst":"cp_quant_genes_target"} ]
+		"cmd":[ "bash -c 'if [ -e $0 ]; then cp $0 $1; else >&2 printf \"No such file: %s\" $0; exit 0; fi'", 
+				{"port":"src_quant_genes", "direction":"in"}, {"subst":"quant_genes_target"}
+		],
+		"comment":"if salmon is not run this file is not created"
 	}
 ],
 "edges":[
-	{ "id":"salmon_to_zip_salmon_quant", "from":"salmon", "to":"zip_salmon_quant"},
+	{ "id":"zip_salmon_output", "from":"quant_genes", "to":"zip_salmon_quant"},
 	{ "id":"salmon_to_quant_genes", "from":"salmon", "to":"quant_genes" },
 	{ "id":"cp_quant_genes", "from":"quant_genes", "to":"cp_quant_genes:src_quant_genes" }
 ]

--- a/data/vtlib/star_alignment.json
+++ b/data/vtlib/star_alignment.json
@@ -187,7 +187,19 @@
         "type":"EXEC",
         "use_STDIN": true,
         "use_STDOUT": false,
-        "cmd":["bamtofastq", "gz=0", {"packflag":["F=", {"port":"fq1", "direction":"out"}]}, {"packflag":["F2=", {"port":"fq2", "direction":"out"}]}]
+        "cmd":[
+               "bamtofastq", 
+               "gz=0",
+               {
+                "select":"alignment_reads_layout", 
+                "default":"2", 
+                "select_range":[1],
+                "cases":{
+                         "1":{"packflag":["S=",{"port":"fq1", "direction":"out"}]},
+                         "2":[{"packflag":["F=",{"port":"fq1", "direction":"out"}]}, {"packflag":["F2=",{"port":"fq2", "direction":"out"}]}]
+                }
+               }
+        ]
     },
     {
         "id":"fq1",
@@ -222,7 +234,15 @@
                 {"subst":"chimJunctionOverhangMin_flag"},
                 "--quantMode", "GeneCounts",
                 "--genomeDir", {"port":"reference_genome", "direction":"in"},
-                "--readFilesIn", {"port":"fq1", "direction":"in"}, {"port":"fq2", "direction":"in"},
+                {
+                 "select":"alignment_reads_layout",
+                 "default":"2",
+                 "select_range":[1],
+                 "cases":{
+                          "1":["--readFilesIn", {"port":"fq1", "direction":"in"}],
+                          "2":["--readFilesIn", {"port":"fq1", "direction":"in"}, {"port":"fq2", "direction":"in"}]
+                 }
+                },
                 "--outStd", "BAM_Unsorted"
         ]
     },
@@ -285,18 +305,27 @@
     }
 ],
 "edges":[
-    { "id":"bamtofastq_to_fq1", "from":"bamtofastq:fq1", "to":"fq1" },
-    { "id":"bamtofastq_to_fq2", "from":"bamtofastq:fq2", "to":"fq2" },
-    { "id":"fq1_to_star", "from":"fq1", "to":"star:fq1" },
-    { "id":"fq2_to_star", "from":"fq2", "to":"star:fq2" },
+    {"id":"bamtofastq_to_fq1", "from":"bamtofastq:fq1", "to":"fq1"},
+    { "select":"alignment_reads_layout",
+      "default":2,
+      "select_range":[1],
+      "cases":{ "1":{}, "2":{"id":"bamtofastq_to_fq2", "from":"bamtofastq:fq2", "to":"fq2"} } },
+    {"id":"fq1_to_star", "from":"fq1", "to":"star:fq1"},
+    { "select":"alignment_reads_layout", 
+      "default":2,
+      "select_range":[1],
+      "cases":{ "1":{}, "2":{"id":"fq2_to_star", "from":"fq2", "to":"star:fq2"} } },
     { "id":"star_to_junctions_tab", "from":"star", "to":"junctions_tab" },
     { "id":"cp_junctions_tab", "from":"junctions_tab", "to":"cp_junctions_tab:src_junctions_tab" },
     { "id":"star_to_readspergene_tab", "from":"star", "to":"readspergene_tab" },
     { "id":"cp_readspergene_tab", "from":"readspergene_tab", "to":"cp_readspergene_tab:src_readspergene_tab" },
     { "id":"star_to_stargenome_dir", "from":"star", "to":"STARgenome_dir" },
     { "id":"chmod_stargenome_dir", "from":"STARgenome_dir", "to":"chmod_STARgenome_dir:src_stargenome_dir" },
-    { "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fastq1" },
-    { "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2" },
+    { "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fastq1"},
+    { "select":"alignment_reads_layout", 
+      "default":2,
+      "select_range":[1],
+      "cases":{ "1":{}, "2":{"id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2"} } },
     { "id":"star_to_qname_sort", "from":"star", "to":"bamsort_qname" }
 ]
 }

--- a/data/vtlib/tophat2_alignment.json
+++ b/data/vtlib/tophat2_alignment.json
@@ -200,8 +200,15 @@
 		"cmd":[
 			"bamtofastq",
 			"gz=1",
-			{"packflag":["F=", {"port":"__FQ1_OUT__", "direction":"out"}]},
-			{"packflag":["F2=", {"port":"__FQ2_OUT__", "direction":"out"}]}
+			   {
+				"select":"alignment_reads_layout", 
+				"default":"2", 
+				"select_range":[1],
+				"cases":{
+						 "1":{"packflag":["S=",{"port":"__FQ1_OUT__", "direction":"out"}]},
+						 "2":[{"packflag":["F=",{"port":"__FQ1_OUT__", "direction":"out"}]}, {"packflag":["F2=",{"port":"__FQ2_OUT__", "direction":"out"}]}]
+				}
+			   }
 		]
 	},
 	{
@@ -232,8 +239,15 @@
 				"--no-coverage-search",
 				"--microexon-search",
 				{"port":"__REFERENCE_GENOME_IN__", "direction":"in"},
-				{"port":"__FQ1_IN__", "direction":"in"},
-				{"port":"__FQ2_IN__", "direcion":"in"}
+				{
+					"select":"alignment_reads_layout",
+					"default":"2",
+					"select_range":[1],
+					"cases":{
+						"1":{"port":"__FQ1_IN__", "direction":"in"},
+						"2":[{"port":"__FQ1_IN__", "direction":"in"}, {"port":"__FQ2_IN__", "direcion":"in"}]
+					}
+				}
 		]
 	},
 	{
@@ -331,9 +345,15 @@
 ],
 "edges":[
 	{ "id":"bamtofastq_to_fq1", "from":"bamtofastq:__FQ1_OUT__", "to":"fq1" },
-	{ "id":"bamtofastq_to_fq2", "from":"bamtofastq:__FQ2_OUT__", "to":"fq2" },
+	{ "select":"alignment_reads_layout",
+		"default":2,
+		"select_range":[1],
+		"cases":{ "1":{}, "2":{"id":"bamtofastq_to_fq2", "from":"bamtofastq:__FQ2_OUT__", "to":"fq2"} } },
 	{ "id":"fq1_to_tophat2", "from":"fq1", "to":"tophat2:__FQ1_IN__" },
-	{ "id":"fq2_to_tophat2", "from":"fq2", "to":"tophat2:__FQ2_IN__" },
+	{ "select":"alignment_reads_layout", 
+		"default":2,
+		"select_range":[1],
+		"cases":{ "1":{}, "2":{"id":"fq2_to_tophat2", "from":"fq2", "to":"tophat2:__FQ2_IN__"} } },
 	{ "id":"tophat2_to_accepted_hits_bam", "from":"tophat2", "to":"accepted_hits_bam" },
 	{ "id":"tophat2_to_unmapped_bam", "from":"tophat2", "to":"unmapped_bam" },
 	{ "id":"tophat2_to_deletions_bed", "from":"tophat2", "to":"deletions_bed" },
@@ -346,6 +366,9 @@
 	{ "id":"unmapped_bam_to_bamcat", "from":"unmapped_bam", "to":"bamcat:__IN_BAM2__" },
 	{ "id":"bamcat_to_qname_sort", "from":"bamcat", "to":"bamsort_qname" },
 	{ "id":"fq1_to_quantify", "from":"fq1", "to":"quantify:fastq1" },
-	{ "id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2" }
+	{ "select":"alignment_reads_layout", 
+		"default":2,
+		"select_range":[1],
+		"cases":{ "1":{}, "2":{"id":"fq2_to_quantify", "from":"fq2", "to":"quantify:fastq2"} } }
 ]
 }


### PR DESCRIPTION
1. Changes to support alignment/quantification of single-end libraries using STAR, TopHat2 and Salmon.

2. Wrapped Salmon command in a bash script to validate fastq inputs and exits cleanly if they aren't good enough. Copying the quant_genes file was also wrapped for clean exit in case Salmon wasn't executed.