### PR TITLE
se/pe and nchs fixes 

### DIFF
--- a/data/vtlib/alignment_wtsi_stage2_humansplit_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_humansplit_template.json
@@ -99,6 +99,41 @@
 		"description":"BAM using as input to this pipeline - expected to already contain PhiX (normally from hyb buffer spike-in) alignments"
 	},
 	{
+		"id":"spatial_filter",
+		"type":"EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd":[
+			"bambi",
+			"spatial_filter",
+			"-a",
+			"--compression-level", "0",
+			"-f",
+			"-l", {"port":"apply_stats", "direction":"out"},
+			"-F", {"port":"filter", "direction":"in"},
+			"/dev/stdin"
+		],
+		"description":"apply the spatial filter (produced in stage1)"
+	},
+	{
+		"id":"spatial_filter_file",
+		"type":"INFILE",
+		"name":{"subst":"spatial_filter_file","required":true, "ifnull":{"subst_constructor":{"vals":[ {"subst":"recal_dir"}, "/", {"subst":"s2_id_run"}, "_", {"subst":"s2_position"}, ".spatial_filter" ], "postproc":{"op":"concat","pad":""}}}},
+		"description":"spatial filter file"
+	},
+	{
+		"id":"spatial_filter_stats",
+		"type":"OUTFILE",
+		"name":{"subst":"spatial_filter_stats", "required":true, "ifnull":{"subst_constructor":{"vals":[ {"subst":"outdatadir"}, "/", {"subst":"rpt"}, ".spatial_filter.stats" ], "postproc":{"op":"concat","pad":""}}}} },
+	{
+		"id":"subsample_fqc",
+		"type":"VTFILE",
+		"comment":"inputs: _stdin_ (filtered bam); outputs: _stdout_ (bam, same as input)",
+		"node_prefix":"ssfqc_",
+		"name":{"subst":"subsample_vtf", "ifnull":"subsample.json"},
+		"description":""
+	},
+	{
 		"id":"target_alignment",
 		"type":"VTFILE",
 		"comment":"inputs: _stdin_ (bam), reference, reference dict; outputs: aligned_to_target (bam), aligned_to_phix (bam)",
@@ -186,7 +221,11 @@
 	}
 ],
 "edges":[
-	{ "id":"src_to_bc2", "from":"src_bam", "to":"target_alignment" },
+	{ "id":"src_to_bc2", "from":"src_bam", "to":"spatial_filter" },
+	{ "id":"src_to_bc2", "from":"spatial_filter_file", "to":"spatial_filter:filter" },
+	{ "id":"apply_filter_to_sfqc", "from":"spatial_filter:apply_stats", "to":"spatial_filter_stats" },
+	{ "id":"sf_to_bc2", "from":"spatial_filter", "to":"subsample_fqc" },
+	{ "id":"ssfqc_to_tgtaln", "from":"subsample_fqc:straight_through1", "to":"target_alignment" },
 	{ "id":"target_alignment_to_alignment_filter", "from":"target_alignment:aligned_to_target", "to":"alignment_filter:target_bam_in" },
 	{ "id":"phix_alignment_to_alignment_filter", "from":"target_alignment:aligned_to_phix", "to":"alignment_filter:phix_bam_in" },
 	{ "id":"human_alignment_to_alignment_filter", "from":"target_alignment:aligned_to_human", "to":"alignment_filter:human_bam_in" },
@@ -194,7 +233,7 @@
 	{ "id":"af_to_paf_target", "from":"alignment_filter:target_bam_out", "to":"final_output_prep_target" },
 	{ "id":"af_to_paf_phix", "from":"alignment_filter:phix_bam_out", "to":"final_output_prep_phix" },
 	{ "id":"af_to_paf_hs", "from":"alignment_filter:human_bam_out", "to":"final_output_prep_hs" },
-        { "id":"src_bam_to_seqchksum", "from":"src_bam", "to":"seqchksum" },
+        { "id":"src_to_seqchksum", "from":"subsample_fqc:straight_through2", "to":"seqchksum" },
 	{ "id":"fopt_to_bam", "from":"final_output_prep_target", "to":"seqchksum:target_seqchksum" },
 	{ "id":"fopp_to_bam_phix", "from":"final_output_prep_phix", "to":"seqchksum:phix_seqchksum" },
 	{ "id":"fopp_to_bam_phix", "from":"final_output_prep_hs", "to":"seqchksum:hs_seqchksum" }

--- a/data/vtlib/bcl2bam_phix_deplex_wtsi_stage1_template.json
+++ b/data/vtlib/bcl2bam_phix_deplex_wtsi_stage1_template.json
@@ -346,8 +346,10 @@
 		"cmd":[ "samtools",
 			"fastq",
 			"-F", "0x200",
-			"-1", {"port":"ss_fq1", "direction":"out"},
-			"-2", {"port":"ss_fq2", "direction":"out"},
+			{"select":"s1_se_pe", "default":"pe", "select_range":[1], "cases":{
+				"pe":["-1", {"port":"ss_fq1", "direction":"out"},"-2", {"port":"ss_fq2", "direction":"out"}],
+				"se":["-s", {"port":"ss_fq1", "direction":"out"}]
+			}},
 			"--i1", {"port":"ss_fqt", "direction":"out"},
 			"--index-format", "i99",
                         "-"
@@ -499,7 +501,10 @@
 	{ "id":"tee_to_ss", "from":"tee_split:subsample", "to":"subsample" },
 	{ "id":"ss_to_b2fqss", "from":"subsample", "to":"bamtofastq_ss" },
 	{ "id":"b2fqss_to_fq1", "from":"bamtofastq_ss:ss_fq1", "to":"run_lane_ss_fq1" },
-	{ "id":"b2fqss_to_fq2", "from":"bamtofastq_ss:ss_fq2", "to":"run_lane_ss_fq2" },
+	{"select":"s1_se_pe","select_range":[0,1], "default":"pe", "cases":{
+		"pe":{"id":"b2fqss_to_fq2", "from":"bamtofastq_ss:ss_fq2", "to":"run_lane_ss_fq2"},
+		"se":{}
+	}},
 	{ "id":"b2fqss_to_fqt", "from":"bamtofastq_ss:ss_fqt", "to":"run_lane_ss_fqt" },
 	{ "id":"tee_to_b2fqfqc", "from":"tee_split:fqc", "to":"bamtofastq_fqc" },
 	{ "id":"fq_to_fqc1", "from":"bamtofastq_fqc:fq1", "to":"fastqcheck_r1" },

--- a/data/vtlib/subsample.json
+++ b/data/vtlib/subsample.json
@@ -63,8 +63,10 @@
 			"fastq",
 			"-F", "0x200",
 			"-t",
-			"-1", {"port":"ss_fq1", "direction":"out"},
-			"-2", {"port":"ss_fq2", "direction":"out"},
+			{"select":"s2_se_pe", "default":"pe", "select_range":[1], "cases":{
+				"pe":["-1", {"port":"ss_fq1", "direction":"out"},"-2", {"port":"ss_fq2", "direction":"out"}],
+				"se":["-s", {"port":"ss_fq1", "direction":"out"}]
+			}},
                         "-"
 		]
         },
@@ -89,8 +91,10 @@
 			"fastq",
 			"-F", "0x200",
 			"-t",
-			"-1", {"port":"fq1", "direction":"out"},
-			"-2", {"port":"fq2", "direction":"out"},
+			{"select":"s2_se_pe", "default":"pe", "select_range":[1], "cases":{
+				"pe":["-1", {"port":"fq1", "direction":"out"},"-2", {"port":"fq2", "direction":"out"}],
+				"se":["-s", {"port":"fq1", "direction":"out"}]
+			}},
                         "-"
 		]
         },
@@ -101,13 +105,18 @@
 		"use_STDOUT": true,
 		"cmd":[ "fastqcheck" ]
         },
-        {
-                "id":"fastqcheck_r2",
-                "type":"EXEC",
-		"use_STDIN": true,
-		"use_STDOUT": true,
-		"cmd":[ "fastqcheck" ]
-        },
+	{"select":"s2_se_pe", "default":"pe", "select_range":[0,1], "comment":"node only appears if s2_se_pe is pe",
+           "cases":{
+             "pe":
+		{
+			"id":"fastqcheck_r2",
+			"type":"EXEC",
+			"use_STDIN": true,
+			"use_STDOUT": true,
+			"cmd":[ "fastqcheck" ]
+		},
+             "se":{"comment":"fastqcheck_r2 node removed"}
+	}},
 	{
 		"id":"fqc1",
 		"type":"OUTFILE",
@@ -125,11 +134,23 @@
 	{ "id":"tee_to_ss", "from":"tee_ssfqc:subsample", "to":"subsample" },
 	{ "id":"ss_to_b2fqss", "from":"subsample", "to":"bamtofastq_ss" },
 	{ "id":"b2fqss_to_fq1", "from":"bamtofastq_ss:ss_fq1", "to":"run_lane_ss_fq1" },
-	{ "id":"b2fqss_to_fq2", "from":"bamtofastq_ss:ss_fq2", "to":"run_lane_ss_fq2" },
+	{"select":"s2_se_pe", "default":"pe", "select_range":[0,1], "comment":"edge only appears if s2_se_pe is pe",
+           "cases":{
+	      "pe":{ "id":"b2fqss_to_fq2", "from":"bamtofastq_ss:ss_fq2", "to":"run_lane_ss_fq2" },
+              "se":{"comment":"b2fqss_to_fq2 edge removed"}
+	}},
 	{ "id":"tee_to_b2fqfqc", "from":"tee_ssfqc:fqc", "to":"bamtofastq_fqc" },
 	{ "id":"tee_to_splitter", "from":"bamtofastq_fqc:fq1", "to":"fastqcheck_r1" },
-	{ "id":"tee_to_splitter", "from":"bamtofastq_fqc:fq2", "to":"fastqcheck_r2" },
+	{"select":"s2_se_pe", "default":"pe", "select_range":[0,1], "comment":"edge only appears if s2_se_pe is pe",
+           "cases":{
+	      "pe":{ "id":"bamtofastq_fqx_to_fastqcheck_r2", "from":"bamtofastq_fqc:fq2", "to":"fastqcheck_r2" },
+              "se":{"comment":"bamtofastq_fqx_to_fastqcheck_r2 edge removed"}
+	}},
 	{ "id":"tee_to_splitter", "from":"fastqcheck_r1", "to":"fqc1" },
-	{ "id":"tee_to_splitter", "from":"fastqcheck_r2", "to":"fqc2" }
+	{"select":"s2_se_pe", "default":"pe", "select_range":[0,1], "comment":"edge only appears if s2_se_pe is pe",
+           "cases":{
+             "pe": { "id":"fastqcheck_r2_to_fqc2", "from":"fastqcheck_r2", "to":"fqc2" },
+             "se":{"comment":"fastqcheck_r2_to_fqc2 edge removed"}
+	}}
 ]
 }


### PR DESCRIPTION
add subsampling (fastq 10000) and fastqcheck to non-consented human split
update stage1 and stage2 templates to handle both single- and paired-end runs