### PR TITLE
more s/e fixes

### DIFF
--- a/data/vtlib/bcl2bam_phix_deplex_wtsi_stage1_template.json
+++ b/data/vtlib/bcl2bam_phix_deplex_wtsi_stage1_template.json
@@ -381,8 +381,10 @@
 		"cmd":[ "samtools",
 			"fastq",
 			"-F", "0x200",
-			"-1", {"port":"fq1", "direction":"out"},
-			"-2", {"port":"fq2", "direction":"out"},
+			{"select":"s1_se_pe", "default":"pe", "select_range":[1], "cases":{
+				"pe":["-1", {"port":"fq1", "direction":"out"},"-2", {"port":"fq2", "direction":"out"}],
+				"se":["-0", {"port":"fq1", "direction":"out"}]
+			}},
 			"--i1", {"port":"fqt", "direction":"out"},
 			"--index-format", "i99",
                         "-"
@@ -397,7 +399,7 @@
         },
         {
                 "id":"fastqcheck_r2",
-                "type":"EXEC",
+                "type":{"select":"s1_se_pe", "default":"pe", "select_range":[1], "cases":{"pe":"EXEC","se":"INACTIVE"}},
 		"use_STDIN": true,
 		"use_STDOUT": true,
 		"cmd":[ "fastqcheck" ]
@@ -508,10 +510,16 @@
 	{ "id":"b2fqss_to_fqt", "from":"bamtofastq_ss:ss_fqt", "to":"run_lane_ss_fqt" },
 	{ "id":"tee_to_b2fqfqc", "from":"tee_split:fqc", "to":"bamtofastq_fqc" },
 	{ "id":"fq_to_fqc1", "from":"bamtofastq_fqc:fq1", "to":"fastqcheck_r1" },
-	{ "id":"fq_to_fqc2", "from":"bamtofastq_fqc:fq2", "to":"fastqcheck_r2" },
+	{"select":"s1_se_pe","select_range":[0,1], "default":"pe", "cases":{
+		"pe":{ "id":"fq_to_fqc2", "from":"bamtofastq_fqc:fq2", "to":"fastqcheck_r2" },
+		"se":{}
+	}},
 	{ "id":"fq_to_fqct", "from":"bamtofastq_fqc:fqt", "to":"fastqcheck_rt" },
 	{ "id":"fqc_to_f1", "from":"fastqcheck_r1", "to":"fqc1" },
-	{ "id":"fqc_to_f2", "from":"fastqcheck_r2", "to":"fqc2" },
+	{"select":"s1_se_pe","select_range":[0,1], "default":"pe", "cases":{
+		"pe":{ "id":"fqc_to_f2", "from":"fastqcheck_r2", "to":"fqc2" },
+		"se":{}
+	}},
 	{ "id":"fqc_to_ft", "from":"fastqcheck_rt", "to":"fqct" },
 	{ "id":"tee_to_stats", "from":"tee_split:stats", "to":"samtools_stats" },
 	{ "id":"stats_to_file", "from":"samtools_stats", "to":"lane_stats_file" },

--- a/data/vtlib/subsample.json
+++ b/data/vtlib/subsample.json
@@ -62,7 +62,6 @@
 		"cmd":[ "samtools",
 			"fastq",
 			"-F", "0x200",
-			"-t",
 			{"select":"s2_se_pe", "default":"pe", "select_range":[1], "cases":{
 				"pe":["-1", {"port":"ss_fq1", "direction":"out"},"-2", {"port":"ss_fq2", "direction":"out"}],
 				"se":["-0", {"port":"ss_fq1", "direction":"out"}]
@@ -90,10 +89,9 @@
 		"cmd":[ "samtools",
 			"fastq",
 			"-F", "0x200",
-			"-t",
 			{"select":"s2_se_pe", "default":"pe", "select_range":[1], "cases":{
 				"pe":["-1", {"port":"fq1", "direction":"out"},"-2", {"port":"fq2", "direction":"out"}],
-				"se":["-s", {"port":"fq1", "direction":"out"}]
+				"se":["-0", {"port":"fq1", "direction":"out"}]
 			}},
                         "-"
 		]


### PR DESCRIPTION
- apply single-end changes to fastq production for fastqcheck input in stage1 analysis
- correct samtools fastq flag to "-0" from "-s" for single-end fastq stream used for fastqcheck production in stage2 analysis
- remove unneeded -t flag from samtools fastq command in stage2 analysis