### PR TITLE
Ensure Perl exec without wrapping shell

### DIFF
--- a/data/bwa_post_proc.vtf
+++ b/data/bwa_post_proc.vtf
@@ -1,7 +1,7 @@
 {
 "description":"A HiSeqX processing pipeline",
-"version":"1.0",
-"subgraph_io":{"ports":{"inputs":{"_stdin_":"scramble_sam_to_bam","reference_picard_dict":"alterSQ_headerSQfix:__IN_PICARD_DICT__","prealign":"bam12auxmerge:__PREALN_BAM__"},"outputs":{"_stdout_":"bam12auxmerge"}}},
+"version":"2.0",
+"subgraph_io":{"ports":{"inputs":{"_stdin_":"scramble_sam_to_bam","reference_picard_dict":"alterSQ_headerSQfix:picard_dict","prealign":"bam12auxmerge:prealn_bam"},"outputs":{"_stdout_":"bam12auxmerge"}}},
 "subst_params":[
 	{"id":"rpt","required":"yes"},
 	{"id":"tmpdir","required":"no","default":"."},
@@ -94,7 +94,7 @@
 	{
 		"id":"reheader_headerSQfix",
 		"type":"EXEC",
-		"cmd":"samtools reheader __IN_SAMHEADER__ __IN_BAM__"
+		"cmd":["samtools", "reheader", {"port":"samheader", "direction":"in"}, {"port":"bam", "direction":"in"} ]
 	},
 	{
 		"id":"bam12split",
@@ -109,7 +109,7 @@
 	{
 		"id":"bam12auxmerge",
 		"type":"EXEC",
-		"cmd":"bam12auxmerge level=0 rankstrip=1 ranksplit=0 zztoname=0 clipreinsert=1 __PREALN_BAM__"
+		"cmd":["bam12auxmerge", "level=0", "rankstrip=1", "ranksplit=0", "zztoname=0", "clipreinsert=1", {"port":"prealn_bam", "direction":"in"} ]
 	}
 ],
 "edges":[
@@ -131,12 +131,12 @@
 	{
 		"id":"alterSQ_headerSQfix_to_reheader",
 		"from":"alterSQ_headerSQfix",
-		"to":"reheader_headerSQfix:__IN_SAMHEADER__"
+		"to":"reheader_headerSQfix:samheader"
 	},
 	{
 		"id":"tee_headerSQfix_to_reheader",
 		"from":"tee_bwa",
-		"to":"reheader_headerSQfix:__IN_BAM__"
+		"to":"reheader_headerSQfix:bam"
 	},
 	{
 		"id":"reheader_headerSQfix_to_bam12split",

--- a/data/bwa_post_proc.vtf
+++ b/data/bwa_post_proc.vtf
@@ -86,8 +86,9 @@
 	{
 		"id":"alterSQ_headerSQfix",
 		"type":"EXEC",
-		"cmd":"perl -nle 'use strict; use autodie; our%sq; our$re; our$body; BEGIN{$body=0; $re=qr/^\\@SQ.*\\tSN:([^\\t]+)/; open(my$df,q(<),shift@ARGV); while(<$df>){chomp; if(/$re/){$sq{$1}=$_;} } close $df; } next if $body ; if(/$re/){$_=$sq{$1}||$_}elsif(/^[^@]/){open STDOUT,q(>),q(/dev/null); $body=1; next} print' __IN_PICARD_DICT__",
-		"comment":"careful to not send SIGPIPE back to tee, yet ensure EOF to reheader as soon as header processed",
+		"cmd":["perl", "-nle", "use strict; use autodie; our%sq; our$re; our$body; BEGIN{$body=0; $re=qr/^\\@SQ.*\\tSN:([^\\t]+)/; open(my$df,q(<),shift@ARGV); while(<$df>){chomp; if(/$re/){$sq{$1}=$_;} } close $df; } next if $body ; if(/$re/){ if(my$nsq=$sq{$1}){my@ah=grep{/^AH:/}split qq(\\t),$_; $_=join qq(\\t),$nsq,@ah;} }elsif(/^[^@]/){open STDOUT,q(>),q(/dev/null); $body=1; next} print",{"port":"picard_dict", "direction":"in"}],
+		"comment":"careful to not send SIGPIPE back to tee, yet ensure EOF to reheader as soon as header processed, separate arguments to avoid being wrapped by a shell (which might hang onto file handles breaking this intention)",
+
 		"description":"where SN field in SQ header record matches one in the given dict file, replace that SQ record with that in the dict file"
 	},
 	{

--- a/data/vtlib/post_alignment.json
+++ b/data/vtlib/post_alignment.json
@@ -47,11 +47,10 @@
 	{
 		"id":"alterSQ_headerSQfix",
 		"type":"EXEC",
-		"subtype":"STRINGIFY",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd":["perl -nle 'use strict; use autodie; our%sq; our$re; our$body; BEGIN{$body=0; $re=qr/^\\@SQ.*\\tSN:([^\\t]+)/; open(my$df,q(<),shift@ARGV); while(<$df>){chomp; if(/$re/){$sq{$1}=$_;} } close $df; } next if $body ; if(/$re/){ if(my$nsq=$sq{$1}){my@ah=grep{/^AH:/}split qq(\\t),$_; $_=join qq(\\t),$nsq,@ah;} }elsif(/^[^@]/){open STDOUT,q(>),q(/dev/null); $body=1; next} print'",{"port":"picard_dict", "direction":"in"}],
-		"comment":"careful to not send SIGPIPE back to tee, yet ensure EOF to reheader as soon as header processed",
+		"cmd":["perl", "-nle", "use strict; use autodie; our%sq; our$re; our$body; BEGIN{$body=0; $re=qr/^\\@SQ.*\\tSN:([^\\t]+)/; open(my$df,q(<),shift@ARGV); while(<$df>){chomp; if(/$re/){$sq{$1}=$_;} } close $df; } next if $body ; if(/$re/){ if(my$nsq=$sq{$1}){my@ah=grep{/^AH:/}split qq(\\t),$_; $_=join qq(\\t),$nsq,@ah;} }elsif(/^[^@]/){open STDOUT,q(>),q(/dev/null); $body=1; next} print",{"port":"picard_dict", "direction":"in"}],
+		"comment":"careful to not send SIGPIPE back to tee, yet ensure EOF to reheader as soon as header processed, separate arguments to avoid being wrapped by a shell (which might hang onto file handles breaking this intention)",
 		"description":"where SN field in SQ header record matches one in the given dict file, replace that SQ record with that in the dict file, but propagate any 'AH' fields provided by the aligner"
 	},
 	{

--- a/data/vtlib/post_alignment_realignment.json
+++ b/data/vtlib/post_alignment_realignment.json
@@ -50,8 +50,8 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd":"perl -nle 'use strict; use autodie; our%sq; our$re; our$body; BEGIN{$body=0; $re=qr/^\\@SQ.*\\tSN:([^\\t]+)/; open(my$df,q(<),shift@ARGV); while(<$df>){chomp; if(/$re/){$sq{$1}=$_;} } close $df; } next if $body ; if(/$re/){ if(my$nsq=$sq{$1}){my@ah=grep{/^AH:/}split qq(\\t),$_; $_=join qq(\\t),$nsq,@ah;} }elsif(/^[^@]/){open STDOUT,q(>),q(/dev/null); $body=1; next} print' __IN_PICARD_DICT__",
-		"comment":"careful to not send SIGPIPE back to tee, yet ensure EOF to reheader as soon as header processed",
+		"cmd":["perl", "-nle", "use strict; use autodie; our%sq; our$re; our$body; BEGIN{$body=0; $re=qr/^\\@SQ.*\\tSN:([^\\t]+)/; open(my$df,q(<),shift@ARGV); while(<$df>){chomp; if(/$re/){$sq{$1}=$_;} } close $df; } next if $body ; if(/$re/){ if(my$nsq=$sq{$1}){my@ah=grep{/^AH:/}split qq(\\t),$_; $_=join qq(\\t),$nsq,@ah;} }elsif(/^[^@]/){open STDOUT,q(>),q(/dev/null); $body=1; next} print",{"port":"picard_dict", "direction":"in"}],
+		"comment":"careful to not send SIGPIPE back to tee, yet ensure EOF to reheader as soon as header processed, separate arguments to avoid being wrapped by a shell (which might hang onto file handles breaking this intention)",
 		"description":"where SN field in SQ header record matches one in the given dict file, replace that SQ record with that in the dict file, but propagate any 'AH' fields provided by the aligner"
 	},
 	{

--- a/data/vtlib/post_alignment_realignment.json
+++ b/data/vtlib/post_alignment_realignment.json
@@ -1,12 +1,12 @@
 {
-"version":"1.0",
+"version":"2.0",
 "description":"any post-alignment processing required before passing through AlignmentFilter",
 "subgraph_io":{
         "ports":{
                 "inputs":{
                         "_stdin_":"tee_headerSQfix",
-                        "reference_dict":"alterSQ_headerSQfix:__IN_PICARD_DICT__",
-                        "no_align_bam":"bam12auxmerge:__NO_ALN_BAM_IN__"
+                        "reference_dict":"alterSQ_headerSQfix:picard_dict",
+                        "no_align_bam":"bam12auxmerge:no_aln_bam"
                 },
                 "outputs":{
                         "_stdout_":"bam12auxmerge"
@@ -35,7 +35,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": false,
-		"cmd":["teepot", {"subst":"teepot_vflag", "ifnull":"-v"}, {"subst":"teepot_tempdir_flag"}, "-w", "300", "-m", {"subst":"SQhdr_teepot_mval", "ifnull":"100M"}, "__HEADER_FIX_OUT__", "__FULL_BAM_OUT__"],
+		"cmd":["teepot", {"subst":"teepot_vflag", "ifnull":"-v"}, {"subst":"teepot_tempdir_flag"}, "-w", "300", "-m", {"subst":"SQhdr_teepot_mval", "ifnull":"100M"}, {"port":"header_fix","direction":"out"}, {"port":"full_bam","direction":"out"}],
 		"comment":"get deadlock when tee used here; specify parameter value teepot_tempdir_value to specify teepot tempdir"
 	},
 	{
@@ -66,7 +66,7 @@
 		"type":"EXEC",
 		"use_STDIN": false,
 		"use_STDOUT": true,
-		"cmd":[ {"subst":"samtools_executable"}, "reheader", "__IN_SAMHEADER__", "__IN_BAM__" ]
+		"cmd":[ {"subst":"samtools_executable"}, "reheader", {"port":"samheader", "direction":"in"}, {"port":"bam", "direction":"in"} ]
 	},
 	{
 		"id":"bam12split",
@@ -94,16 +94,16 @@
 			"ranksplit=0",
 			"zztoname=0",
 			{"subst":"clipreinsert_flag","required":"yes","ifnull":{"subst_constructor":{"vals":[ "clipreinsert", {"subst":"clipreinsert_val", "required":"yes", "ifnull":"1"} ],"postproc":{"op":"concat","pad":"="}}}},
-			"__NO_ALN_BAM_IN__"
+			{"port":"no_aln_bam", "direction":"in"}
 		]
 	}
 ],
 "edges":[
-	{ "id":"tee_headerSQfix_to_sam", "from":"tee_headerSQfix:__HEADER_FIX_OUT__", "to":"sam_headerSQfix" },
+	{ "id":"tee_headerSQfix_to_sam", "from":"tee_headerSQfix:header_fix", "to":"sam_headerSQfix" },
 	{ "id":"sam_headerSQfix_to_alterSQ", "from":"sam_headerSQfix", "to":"alterSQ_headerSQfix" },
-	{ "id":"alterSQ_headerSQfix_to_reheader", "from":"alterSQ_headerSQfix", "to":"reheader_headerSQfix:__IN_SAMHEADER__" },
-	{ "id":"tee_headerSQfix_to_mbuffer", "from":"tee_headerSQfix:__FULL_BAM_OUT__", "to":"mbuffer_headerSQfix" },
-	{ "id":"mbuffer_headerSQfix_to_reheader", "from":"mbuffer_headerSQfix", "to":"reheader_headerSQfix:__IN_BAM__" },
+	{ "id":"alterSQ_headerSQfix_to_reheader", "from":"alterSQ_headerSQfix", "to":"reheader_headerSQfix:samheader" },
+	{ "id":"tee_headerSQfix_to_mbuffer", "from":"tee_headerSQfix:full_bam", "to":"mbuffer_headerSQfix" },
+	{ "id":"mbuffer_headerSQfix_to_reheader", "from":"mbuffer_headerSQfix", "to":"reheader_headerSQfix:bam" },
 	{ "id":"reheader_headerSQfix_to_bam12split", "from":"reheader_headerSQfix", "to":"bam12split" },
 	{ "id":"bam12split_to_bamsort_qname", "from":"bam12split", "to":"bamsort_qname" },
 	{ "id":"bsqn_to_bam12auxmerge", "from":"bamsort_qname", "to":"bam12auxmerge" }


### PR DESCRIPTION
Bugfix to avoid (temporary) deadlocks apparent when running with default shell `dash` on Bionic rather than on Precise where we've had the default shell set to `bash`