### PR TITLE
Standardise realign

### DIFF
--- a/data/vtlib/auxmerge_prep.json
+++ b/data/vtlib/auxmerge_prep.json
@@ -28,7 +28,7 @@
 		"cmd":{"select":"realignment_switch", "select_range":[1], "default":0, "comment":"only preserve aux tags for realignment (realignment is non-default)",
 			"cases":[
 				["bamreset", "resetaux=0", "level=0", "verbose=0"],
-				["bamreset", "resetaux=0", "auxfilter=RG,PG,BC,RT,QT,tr,tq,br,qr", "level=0", "verbose=0"]
+				["bamreset", "resetaux=0", "auxfilter=RG,PG,BC,RT,QT,OX,BZ,tr,tq,br,qr", "level=0", "verbose=0"]
 			]
 		},
 		"comment":"bam12auxmerge <= 0.0.142 requires SQ headers removed. Alignment removal also required for bamadapterclip (at least 0.0.142)"

--- a/data/vtlib/auxmerge_prep.json
+++ b/data/vtlib/auxmerge_prep.json
@@ -9,19 +9,29 @@
 },
 "nodes":[
 	{
-		"id":"bamreset_pre_auxmerge",
-		"type":"EXEC",
-		"use_STDIN": true,
-		"use_STDOUT": true,
-		"cmd":["bamreset", "resetaux=0", "level=0", "verbose=0"],
-		"comment":"bam12auxmerge <= 0.0.142 requires SQ headers removed. Alignment removal also required for bamadapterclip (at least 0.0.142)"
-	},
-	{
 		"id":"bamadapterclip_pre_auxmerge",
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd":["bamadapterclip", "verbose=0", "level=0"]
+		"cmd":{"select":"realignment_switch", "select_range":[1], "default":0,"comment":"detect and clip for realign, otherwise just clip (realignment is non-default)",
+			"cases":[
+				["bamadapterclip", "verbose=0", "level=0"],
+				["bamadapterfind", "clip=1", "verbose=0", "level=0"]
+			]
+		}
+	},
+	{
+		"id":"bamreset_pre_auxmerge",
+		"type":"EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd":{"select":"realignment_switch", "select_range":[1], "default":0, "comment":"only preserve aux tags for realignment (realignment is non-default)",
+			"cases":[
+				["bamreset", "resetaux=0", "level=0", "verbose=0"],
+				["bamreset", "resetaux=0", "auxfilter=RG,PG,BC,RT,QT,tr,tq,br,qr", "level=0", "verbose=0"]
+			]
+		},
+		"comment":"bam12auxmerge <= 0.0.142 requires SQ headers removed. Alignment removal also required for bamadapterclip (at least 0.0.142)"
 	}
 ],
 "edges":[

--- a/data/vtlib/pre_alignment.json
+++ b/data/vtlib/pre_alignment.json
@@ -39,7 +39,12 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd":[ "bamadapterclip", "verbose=0", "level=0" ],
+		"cmd":{"select":"realignment_switch", "select_range":[1], "default":0, "comment":"detect and clip for realign, otherwise just clip (realignment is non-default)",
+			"cases":[
+				["bamadapterclip", "verbose=0", "level=0"],
+				["bamadapterfind", "clip=1", "verbose=0", "level=0"]
+			]
+		},
 		"description":"Hard clip adapter sequence from reads before feeding to Tophat2"
 	}
 ],

--- a/data/vtlib/split_by_chromosome.json
+++ b/data/vtlib/split_by_chromosome.json
@@ -35,8 +35,8 @@
 	{
 		"id":"split",
 		"type":"EXEC",
-		"use_STDIN": true,
-		"use_STDOUT": true,
+		"use_STDIN": false,
+		"use_STDOUT": false,
 		"cmd":["bambi", "chrsplit", "--exclude", "__SPLIT_OUT__", "--input", "__DATA_IN__", "--output", "__TARGET_OUT__", {"subst":"chrsplit_subset_flag"}, {"subst":"chrsplit_invert_flag"}]
 	},
 	{


### PR DESCRIPTION
Add options to standard stage2 templates to handle realignment. This allow use of the stage2 analysis template alignment_wtsi_stage2_template.json and components to do realignments.