### PR TITLE
change prefix for SamHaplotag log files

### DIFF
--- a/data/vtlib/haplotagging.json
+++ b/data/vtlib/haplotagging.json
@@ -40,7 +40,7 @@
 					"subst_constructor":{
 						"vals":[
 							"--prefix",
-							{"subst":"ht_prefix", "required":true, "ifnull":{"subst_constructor":{"vals":[ "outdatalink/", {"subst":"rpt"} ], "postproc":{"op":"concat","pad":""}}}}
+							{"subst":"ht_prefix", "required":true, "ifnull":{"subst_constructor":{"vals":[ "outdatalink/", {"subst":"rpt"}, "." ], "postproc":{"op":"concat","pad":""}}}}
 						]
 					}
 				}


### PR DESCRIPTION
change prefix for SamHaplotag log files to include a trailing '.'. This simplifies npg_irods archival.