### PR TITLE
markdup_method:none for phix and non-consented human split

### DIFF
--- a/data/vtlib/alignment_wtsi_stage2_humansplit_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_humansplit_template.json
@@ -278,7 +278,7 @@
 			"phix_or_target":{"subst":"hs_indicator"},
 			"fopid":{"subst":"fopid_hs"},
 			"c2a_switch":{"subst":"c2a_hs"},
-			"c2a_switch":{"subst":"c2a_phix"},
+			"primer_clip_method":"no_clip",
 			"markdup_method":"none",
 			"bstmp":"bsfoph","brtmp":"brfoph","bmdtmp":"bmdfoph",
 			"scramble_reference_fasta":{"subst":"hs_reference_genome_fasta"},

--- a/data/vtlib/alignment_wtsi_stage2_humansplit_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_humansplit_template.json
@@ -256,7 +256,16 @@
                 "type":"VTFILE",
 		"comment":"inputs: _stdin_ (bam); outputs: _stdout_ (seqchksum)",
 		"node_prefix":"fopphx_",
-                "subst_map":{"phix_or_target":{"subst":"phix_indicator"},"fopid":{"subst":"fopid_phix"},"c2a_switch":{"subst":"c2a_phix"},"bstmp":"bsfopp","brtmp":"brfopp","bmdtmp":"bmdfopp","scramble_reference_fasta":{"subst":"phix_reference_genome_fasta"}},
+                "subst_map":{
+			"phix_or_target":{"subst":"phix_indicator"},
+			"fopid":{"subst":"fopid_phix"},
+			"c2a_switch":{"subst":"c2a_phix"},
+			"markdup_method":"none",
+			"primer_clip_method":"no_clip",
+			"bstmp":"bsfopp","brtmp":"brfopp","bmdtmp":"bmdfopp",
+			"scramble_reference_fasta":{"subst":"phix_reference_genome_fasta"},
+			"reference_genome_fasta":{"subst":"phix_reference_genome_fasta"}
+		},
                 "name":{"subst":"final_output_prep_phix"},
                 "description":"subgraph containing post alignment_filter process (phix)"
         },
@@ -265,7 +274,16 @@
                 "type":"VTFILE",
 		"comment":"inputs: _stdin_ (bam); outputs: _stdout_ (seqchksum)",
 		"node_prefix":"fophs_",
-                "subst_map":{"phix_or_target":{"subst":"hs_indicator"},"fopid":{"subst":"fopid_hs"},"c2a_switch":{"subst":"c2a_hs"},"bstmp":"bsfoph","brtmp":"brfoph","bmdtmp":"bmdfoph","scramble_reference_fasta":{"subst":"hs_reference_genome_fasta"}},
+                "subst_map":{
+			"phix_or_target":{"subst":"hs_indicator"},
+			"fopid":{"subst":"fopid_hs"},
+			"c2a_switch":{"subst":"c2a_hs"},
+			"c2a_switch":{"subst":"c2a_phix"},
+			"markdup_method":"none",
+			"bstmp":"bsfoph","brtmp":"brfoph","bmdtmp":"bmdfoph",
+			"scramble_reference_fasta":{"subst":"hs_reference_genome_fasta"},
+			"reference_genome_fasta":{"subst":"hs_reference_genome_fasta"}
+		},
                 "name":{"subst":"final_output_prep_hs"},
                 "description":"subgraph containing post alignment_filter process (phix)"
         },

--- a/data/vtlib/alignment_wtsi_stage2_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_template.json
@@ -241,7 +241,16 @@
                 "type":"VTFILE",
 		"comment":"inputs: _stdin_ (bam); outputs: _stdout_ (seqchksum)",
 		"node_prefix":"fopphx_",
-                "subst_map":{"phix_or_target":{"subst":"phix_indicator"},"fopid":{"subst":"fopid_phix"},"c2a_switch":{"subst":"c2a_phix"},"bstmp":"bsfopp","brtmp":"brfopp","bmdtmp":"bmdfopp","scramble_reference_fasta":{"subst":"phix_reference_genome_fasta"}},
+		"subst_map":{
+			"phix_or_target":{"subst":"phix_indicator"},
+			"fopid":{"subst":"fopid_phix"},
+			"c2a_switch":{"subst":"c2a_phix"},
+			"markdup_method":"none",
+			"primer_clip_method":"no_clip",
+			"bstmp":"bsfopp","brtmp":"brfopp","bmdtmp":"bmdfopp",
+			"scramble_reference_fasta":{"subst":"phix_reference_genome_fasta"},
+			"reference_genome_fasta":{"subst":"phix_reference_genome_fasta"}
+		},
                 "name":{"subst":"final_output_prep_phix"},
                 "description":"subgraph containing post alignment_filter process (phix)"
         },

--- a/data/vtlib/markdup_none.json
+++ b/data/vtlib/markdup_none.json
@@ -61,7 +61,6 @@
 			{"select":"calmd_quiet_mode", "required":true, "select_range":[1], "default":"on", "cases":{"on":"-Q","off":[]}},
 			{"select":"calmd_BQ_tag_compute", "required":true, "select_range":[1], "default":"off", "cases":{"on":"-r","off":[]}},
 			{"select":"calmd_extended_BAQ", "required":true, "select_range":[1], "default":"off", "cases":{"on":"-E","off":[]}},
-			{"select":"calmd_BQ_tag_compute", "required":true, "select_range":[1], "default":"off", "cases":{"on":["--reference", {"subst":"alignment_reference_genome","required":true}],"off":[]}},
 			{"subst":"calmd_extra_flags", "required":false},
 			"-", {"subst":"reference_genome_fasta","required":true}
 		]


### PR DESCRIPTION
for phix (by alignment) and non-consented human split: force markdup_method to "none", with primer_clip_method set to "no_clip"; and reference_genome_fasta (used by calmd) set to the value of parameter "phix_reference_genome_fasta" for phix and to the value of parameter "hs_reference_genome_fasta" for non-consented human

remove --reference flag from calmd command in markdup_none - this is both unnecessary and causes problems when combining markdup_method:none with no_target_alignment