### PR TITLE
use ubuntu latest in github runners

### DIFF
--- a/.github/workflows/testing_and_building_repo.yml
+++ b/.github/workflows/testing_and_building_repo.yml
@@ -1,25 +1,21 @@
 name: testing_and_building_repo
 on: [push, pull_request]
 jobs:
-  build: 
-    strategy:
-      matrix:
-        os: ['ubuntu-18.04']
-        
-    runs-on: ${{matrix.os}} 
-    name: Distribution Perl on ${{ matrix.os }} 
+  build:
+    runs-on: ubuntu-latest
+    name: Distribution Perl on ubuntu-latest
     steps:
-    - uses: actions/checkout@v2 
-    
+    - uses: actions/checkout@v2
+
    # Caching cpanm external modules
     - name: Cache cpanm external modules
       id: cpanmCache
       uses: actions/cache@v2
       with:
-        path: ~/perl5ext  
-        key: ${{ matrix.os}}-build-cpanm-external
- 
-    - name: install cpanm 
+        path: ~/perl5ext
+        key: ${{ runner.os }}-build-cpanm-external
+
+    - name: install cpanm
       run: |
           wget -qO - https://cpanmin.us | /usr/bin/perl - --sudo App::cpanminus
 
@@ -29,9 +25,9 @@ jobs:
           cpanm --local-lib=~/perl5ext local::lib && eval $(perl -I ~/perl5ext/lib/perl5/ -Mlocal::lib)
           ${GITHUB_WORKSPACE}/scripts/install_npg_perl_dependencies.sh $WTSI_NPG_GITHUB_URL $WTSI_NPG_BUILD_BRANCH
       env:
-        WTSI_NPG_GITHUB_URL: https://github.com/wtsi-npg 
+        WTSI_NPG_GITHUB_URL: https://github.com/wtsi-npg
         WTSI_NPG_BUILD_BRANCH: ${GITHUB_HEAD_REF}
-      
+
     - name: install cpanm dependencies
       run: |
           eval $(perl -I ~/perl5ext/lib/perl5/ -Mlocal::lib=~/perl5npg)
@@ -48,17 +44,17 @@ jobs:
           ./Build install
 
     # running ./Build dist and exporting files
-    - name: run ./Build dist  
+    - name: run ./Build dist
       run: |
           eval $(perl -I ~/perl5ext/lib/perl5/ -Mlocal::lib=~/perl5ext)
-          export TEST_AUTHOR=1          
+          export TEST_AUTHOR=1
           ./Build dist
           export DIST_FILE=$(ls p4-*.tar.gz)
           export MD5_FILE=$DIST_FILE.md5
           md5sum $DIST_FILE > $MD5_FILE
           export SHA256_FILE=$DIST_FILE.sha256
           shasum -a 256 $DIST_FILE > $SHA256_FILE
-   
+
     # Archive logs if failure
     - name: Archive CPAN logs
       if: ${{ failure() }}

--- a/.github/workflows/testing_and_building_repo.yml
+++ b/.github/workflows/testing_and_building_repo.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-   # Caching cpanm external modules
+    # Caching cpanm external modules
     - name: Cache cpanm external modules
       id: cpanmCache
       uses: actions/cache@v2

--- a/t/10-vtfp-array_expansion.t
+++ b/t/10-vtfp-array_expansion.t
@@ -6,16 +6,18 @@ use JSON;
 
 my $template = q[t/data/10-vtfp-array_expansion.json];
 my $template_v2 = q[t/data/10-vtfp-array_expansion.v2.json];
+my $which_echo = `which echo`;
+chomp $which_echo;
 
 {
 # the template contains a set of possibly multivalued parameters p1 - p5 which should expand into a list (array ref) in the cmd attribute of its one node
 
 my $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 $template |");
-my $c = {version => q[1.0], edges=> [], nodes => [ {cmd => [q~/bin/echo~,q~1A~,q~1B~,q~2A~,q~3A~,q~3B~,q~3C~,q~3D~,q~4A~,q~5A~,q~5B~], type => q~EXEC~, id => q~n1~, }]};
+my $c = {version => q[1.0], edges=> [], nodes => [ {cmd => [qq~$which_echo~,q~1A~,q~1B~,q~2A~,q~3A~,q~3B~,q~3C~,q~3D~,q~4A~,q~5A~,q~5B~], type => q~EXEC~, id => q~n1~, }]};
 is_deeply ($vtfp_results, $c, 'first array element expansion test');
 
 $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 $template_v2 |");
-$c = {version => q[2.0], edges=> [], nodes => [ {cmd => [q~/bin/echo~,q~1A~,q~1B~,q~2A~,q~3A~,q~3B~,q~3C~,q~3D~,q~4A~,q~5A~,q~5B~], type => q~EXEC~, id => q~n1~, }]};
+$c = {version => q[2.0], edges=> [], nodes => [ {cmd => [qq~$which_echo~,q~1A~,q~1B~,q~2A~,q~3A~,q~3B~,q~3C~,q~3D~,q~4A~,q~5A~,q~5B~], type => q~EXEC~, id => q~n1~, }]};
 is_deeply ($vtfp_results, $c, 'first array element expansion test (v2)');
 }
 

--- a/t/10-vtfp-param_ring.t
+++ b/t/10-vtfp-param_ring.t
@@ -7,7 +7,8 @@ use JSON;
 use Cwd;
 
 my $template = q[t/data/10-vtfp-param_ring.json];
-
+my $which_echo = `which echo`;
+chomp $which_echo;
 
 # first, failure
 # the template contains a ring of parameter defaults p2->p3->p4->p5->p2. This will lead to an infinite recursion error
@@ -30,7 +31,7 @@ subtest 'irdetect' => sub {
 #  p1 - p4 will appear in the resulting cmd attribute (if they are set).
 
 my $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 -keys p3 -vals break $template |");
-my $c = {version => q[1.0], edges=> [], nodes => [ {cmd => [q~/bin/echo~,q~one~,q~break~,q~break~,q~break~], type => q~EXEC~, id => q~n1~}]};
+my $c = {version => q[1.0], edges=> [], nodes => [ {cmd => [qq~$which_echo~,q~one~,q~break~,q~break~,q~break~], type => q~EXEC~, id => q~n1~}]};
 is_deeply ($vtfp_results, $c, 'first parameter ring test');
 }
 
@@ -39,7 +40,7 @@ is_deeply ($vtfp_results, $c, 'first parameter ring test');
 #  not involved the ring (p1)
 
 my $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 -keys p1,p2,p4 -vals first,second,fourth $template |");
-my $c = {version => q[1.0], edges => [], nodes => [ {cmd => [q~/bin/echo~,q~first~,q~second~,q~fourth~,q~fourth~], type => q~EXEC~, id => q~n1~}]};
+my $c = {version => q[1.0], edges => [], nodes => [ {cmd => [qq~$which_echo~,q~first~,q~second~,q~fourth~,q~fourth~], type => q~EXEC~, id => q~n1~}]};
 is_deeply ($vtfp_results, $c, 'second parameter ring test');
 }
 
@@ -48,7 +49,7 @@ is_deeply ($vtfp_results, $c, 'second parameter ring test');
 # but not referenced directly in the node cmd) to confirm that the value propagates through the defaults to p2, p3, and p4
 
 my $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 -nullkeys p1 -keys p5 -vals fifth $template |");
-my $c = {version => q[1.0], edges => [], nodes => [ {cmd => [q~/bin/echo~,q~fifth~,q~fifth~,q~fifth~], type => q~EXEC~, id => q~n1~}]};
+my $c = {version => q[1.0], edges => [], nodes => [ {cmd => [qq~$which_echo~,q~fifth~,q~fifth~,q~fifth~], type => q~EXEC~, id => q~n1~}]};
 is_deeply ($vtfp_results, $c, 'third parameter ring test');
 }
 

--- a/t/10-vtfp-pv.t
+++ b/t/10-vtfp-pv.t
@@ -12,6 +12,8 @@ my $tdir = tempdir(CLEANUP => 1);
 my $template = q[t/data/10-vtfp-pv.json];
 my $pv_file = $tdir.q[/10-vtfp-pv.pv];
 my $processed_template = $tdir.q[/10-vtfp-pv-processed.json];
+my $which_echo = `which echo`;
+chomp $which_echo;
 
 # just export and reimport parameter values for a template
 subtest 'pv0' => sub {
@@ -24,7 +26,7 @@ subtest 'pv0' => sub {
 
 	my $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 -param_vals $pv_file $template |");
 	my $c = from_json(slurp $processed_template);
-	$expected = {version => q[1.0], edges=> [], nodes => [ {cmd => [q~/bin/echo~,q~The~,q~funeral~,q~ends~,q~with~,q~a~,q~mournful~,q~fireworks~,q~display~], type => q~EXEC~, id => q~n1~}]};
+	$expected = {version => q[1.0], edges=> [], nodes => [ {cmd => [qq~$which_echo~,q~The~,q~funeral~,q~ends~,q~with~,q~a~,q~mournful~,q~fireworks~,q~display~], type => q~EXEC~, id => q~n1~}]};
 	is_deeply ($vtfp_results, $c, '(ts1) json config generated using pv file matches original generated config');
 	is_deeply ($vtfp_results, $expected, '(ts1) json config generated using pv file as expected');
 };
@@ -40,7 +42,7 @@ subtest 'pv1' => sub {
 
 	my $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 -param_vals $pv_file $template |");
 	my $c = from_json(slurp $processed_template);
-	$expected = {version => q[1.0], edges=> [], nodes => [ {cmd => [q~/bin/echo~,q~The~,q~party~,q~ends~,q~with~,q~a~,q~deafening~,q~fireworks~,q~display~], type => q~EXEC~, id => q~n1~}]};
+	$expected = {version => q[1.0], edges=> [], nodes => [ {cmd => [qq~$which_echo~,q~The~,q~party~,q~ends~,q~with~,q~a~,q~deafening~,q~fireworks~,q~display~], type => q~EXEC~, id => q~n1~}]};
 	is_deeply ($vtfp_results, $c, '(ts2) json config generated using pv file matches original generated config');
 	is_deeply ($vtfp_results, $expected, '(ts2) json config generated using pv file as expected');
 };
@@ -56,7 +58,7 @@ subtest 'pv2' => sub {
 
 	my $vtfp_results = from_json(slurp "bin/vtfp.pl -verbosity_level 0 -param_vals $pv_file $template |");
 	my $c = from_json(slurp $processed_template);
-	$expected = {version => q[1.0], edges=> [], nodes => [ {cmd => [q~/bin/echo~,q~The~,q~world~,q~ends~,q~with~,q~a~,q~whimper~], type => q~EXEC~, id => q~n1~}]};
+	$expected = {version => q[1.0], edges=> [], nodes => [ {cmd => [qq~$which_echo~,q~The~,q~world~,q~ends~,q~with~,q~a~,q~whimper~], type => q~EXEC~, id => q~n1~}]};
 	is_deeply ($vtfp_results, $c, '(ts4) json config generated using pv file matches original generated config');
 	is_deeply ($vtfp_results, $expected, '(ts4) json config generated using pv file as expected');
 };


### PR DESCRIPTION
Switch to use ubuntu-latest for runners in github
Remove some spaces where not needed in the workflow yml
Use a workaround to find which echo is running instead of hardcoding it. A change in the path for the github worker was causing problems because the new default echo is `/usr/bin/echo` instead of `/bin/echo`