### PR TITLE
fix non-consented human split with bwa-mem2 target alignment

### DIFF
--- a/data/vtlib/target_nchs_alignment.json
+++ b/data/vtlib/target_nchs_alignment.json
@@ -187,6 +187,9 @@
 		"type":"VTFILE",
 		"comment":"inputs: _stdin_ (bam), reference; outputs: _stdout_ (bam)",
 		"node_prefix":"alntgt_hs_",
+                "subst_map":{
+			"bwa_executable":{"subst":"hs_bwa_executable", "ifnull":{"subst":"bwa_executable"}}
+		},
 		"orig_name":{"subst":"alignment_vtf"},
 		"name":{
 			"subst":"alignment_vtf",


### PR DESCRIPTION
if a value is supplied for the parameter hs_bwa_executable, use that for
  non-consented human split alignment with bwa (instead of bwa_executable).
  This is to allow use of a different bwa_executable (e.g. bwa-mem2) for
  target alignment