### PR TITLE
add additional autosome specific coverage threshold

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 CHANGES LOG
 -----------
 
+ - add additional autosome specific coverage threshold to final_output_prep.json
+
 0.37.2
  - change bambi i2b command in stage1 analysis to use new boolean version of --nocall-quality flag
 

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -75,6 +75,7 @@
 	{"id":"stats_filter__F0xB00","required":"no","default":"0xB00"},
 	{"id":"stats_filter__F0xF04","required":"no","default":"0xF04"},
 	{"id":"stats_filter__cov_threshold","required":"no","default":"15"},
+        {"id":"stats_filter__cov_threshold_autosome","required":"no","default":"15"},
 	{"id":"bam_stats_executable","required":"no","default":"bam_stats"},
         {"id":"bait_regions_file","required":"yes","comment":"regions file for optional bait stats"},
         {"id":"target_regions_file","required":"yes","comment":"regions file for optional target regions stats"},
@@ -418,7 +419,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-p", "-g", {"subst":"stats_filter__cov_threshold"},"-F", {"subst":"stats_filter__F0xF04"},"-t",{"subst":"target_autosome_regions_file"},"-" ]
+		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-p", "-g", {"subst":"stats_filter__cov_threshold_autosome"},"-F", {"subst":"stats_filter__F0xF04"},"-t",{"subst":"target_autosome_regions_file"},"-" ]
 	},
 	{
 		"id":"seqchksum",

--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -74,8 +74,6 @@
 	{"id":"stats_filter__F0x900","required":"no","default":"0x900"},
 	{"id":"stats_filter__F0xB00","required":"no","default":"0xB00"},
 	{"id":"stats_filter__F0xF04","required":"no","default":"0xF04"},
-	{"id":"stats_filter__cov_threshold","required":"no","default":"15"},
-        {"id":"stats_filter__cov_threshold_autosome","required":"no","default":"15"},
 	{"id":"bam_stats_executable","required":"no","default":"bam_stats"},
         {"id":"bait_regions_file","required":"yes","comment":"regions file for optional bait stats"},
         {"id":"target_regions_file","required":"yes","comment":"regions file for optional target regions stats"},
@@ -412,14 +410,14 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-p", "-g", {"subst":"stats_filter__cov_threshold"},"-F", {"subst":"stats_filter__F0xF04"},"-t",{"subst":"target_regions_file"},"-" ]
+		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-p", "-g", {"subst":"stats_filter__cov_threshold", "required":true, "ifnull":"15"},"-F", {"subst":"stats_filter__F0xF04"},"-t",{"subst":"target_regions_file"},"-" ]
 	},
 	{
 		"id":"samtools_stats_F0xF04_target_autosome",
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-p", "-g", {"subst":"stats_filter__cov_threshold_autosome"},"-F", {"subst":"stats_filter__F0xF04"},"-t",{"subst":"target_autosome_regions_file"},"-" ]
+		"cmd": [ {"subst":"samtools_executable"}, "stats", {"subst":"stats_reference_flag"}, "-p", "-g", {"subst":"stats_filter__cov_threshold_autosome", "required":true, "ifnull":"15"},"-F", {"subst":"stats_filter__F0xF04"},"-t",{"subst":"target_autosome_regions_file"},"-" ]
 	},
 	{
 		"id":"seqchksum",


### PR DESCRIPTION
To allow the autosome stats stats file to be reused for BGE libraries with a different coverage threshold.