### PR TITLE
bam and cram index creation changes

### DIFF
--- a/data/vtlib/final_output_prep.json
+++ b/data/vtlib/final_output_prep.json
@@ -123,7 +123,7 @@
 		}
 	},
 	{
-		"id":"crai_file",
+		"id":"cram_index_file",
 		"subst_constructor":{
 			"vals":[ {"subst":"outdatadir"}, "/", {"subst":"fopid"}, {"subst":"cram_idx_ext"} ],
 			"postproc":{"op":"concat", "pad":""}
@@ -366,9 +366,14 @@
 	{
 		"id":"cram_index",
 		"type":"EXEC",
-		"use_STDIN": true,
+		"use_STDIN": false,
 		"use_STDOUT": false,
-		"cmd":[ "cram_index", "-", {"subst":"crai_file"} ]
+		"cmd": [
+			{"subst":"samtools_executable", "required":true, "ifnull":"samtools"}, "index",
+			"-o", {"port":"idx", "direction":"out"},
+			{"subst":"cram_index_extra_flags", "required":false},
+			{"port":"cram", "direction":"in"}
+		]
 	},
 	{
 		"id":"cram_seqchksum",
@@ -461,14 +466,15 @@
 		"use_STDOUT": false,
 		"cmd": [
 			{"subst":"samtools_executable", "required":true, "ifnull":"samtools"}, "index",
+			"-o", {"port":"idx", "direction":"out"},
 			{"subst":"diskbam_extra_flags", "required":false},
-			{"port":"bam", "direction":"in"},
-			{"port":"idx", "direction":"out"}
+			{"port":"bam", "direction":"in"}
 		]
 	},
 	{ "id":"bam_file", "type":"RAFILE", "name":{"subst":"bam_file"} },
 	{ "id":"bam_index_file", "type":"OUTFILE", "name":{"subst":"bam_index_file"} },
 	{ "id":"cram_file", "type":"OUTFILE", "name":{"subst":"cram_file"} },
+	{ "id":"cram_index_file", "type":"OUTFILE", "name":{"subst":"cram_index_file"} },
 	{ "id":"bam_md5", "type":"OUTFILE", "name":{"subst":"bam_md5"} },
 	{ "id":"cram_md5", "type":"OUTFILE", "name":{"subst":"cram_md5"} },
 	{ "id":"seqchksum_file", "type":"RAFILE", "name":{"subst":"seqchksum_file"} },
@@ -517,7 +523,8 @@
 		}
 	},
 	{ "id":"cram_tee_to_md5", "from":"cram_tee:md5", "to":"create_cram_md5" },
-	{ "id":"cram_tee_to_crai", "from":"cram_tee:crai", "to":"cram_index" },
+	{ "id":"cram_tee_to_crai", "from":"cram_tee:crai", "to":"cram_index:cram" },
+	{ "id":"cidx_to_file", "from":"cram_index:idx", "to":"cram_index_file" },
 	{ "id":"cram_tee_to_bscs", "from":"cram_tee:seqchksum", "to":"cram_seqchksum" },
 	{ "id":"md5_to_postprocess", "from":"create_cram_md5", "to":"postprocess_md5" },
 	{ "id":"bmdmw_to_sts_F0x900", "from":"bmd_multiway:samtools_stats_F0x900", "to":"samtools_stats_F0x900" },
@@ -535,7 +542,7 @@
 	{ "id":"bmd_to_bam", "from":"bmd_multiway:bam", "to":"diskbam" },
 	{ "id":"stv_to_bam", "from":"diskbam", "to":"bam_file" },
 	{ "id":"bam_to_idx", "from":"bam_file", "to":"bam_index:bam" },
-	{ "id":"idx_to_file", "from":"bam_index:idx", "to":"bam_index_file" },
+	{ "id":"bidx_to_file", "from":"bam_index:idx", "to":"bam_index_file" },
 	{ "id":"bmw_to_md5", "from":"bmd_multiway:md5", "to":"create_bam_md5" },
 	{ "id":"md5_to_bam_postprocess", "from":"create_bam_md5", "to":"postprocess_bam_md5" },
 	{ "id":"corrected_bam_md5_out", "from":"postprocess_bam_md5", "to":"bam_md5" },

--- a/data/vtlib/merge_final_output_prep.json
+++ b/data/vtlib/merge_final_output_prep.json
@@ -59,7 +59,7 @@
        }
     },
     {
-	"id":"crai_file",
+	"id":"cram_index_file",
 	"subst_constructor":{
             "vals":[ {"subst":"outdatadir"}, "/", {"subst":"library"}, {"subst":"cram_idx_ext"} ],
 	    "postproc":{"op":"concat", "pad":""}
@@ -198,7 +198,12 @@
 	"type":"EXEC",
 	"use_STDIN": true,
 	"use_STDOUT": false,
-	"cmd":[ "cram_index", "-", {"subst":"crai_file"} ]
+	"cmd": [
+		{"subst":"samtools_executable", "required":true, "ifnull":"samtools"}, "index",
+		"-o", {"port":"idx", "direction":"out"},
+		{"subst":"cram_index_extra_flags", "required":false},
+		{"port":"cram", "direction":"in"}
+	]
     },
     {
 	"id":"cram_seqchksum",
@@ -271,6 +276,7 @@
         }
    },
     { "id":"local_cram_file", "type":"OUTFILE", "name":{"subst":"local_cram_file"} },
+    { "id":"cram_index_file", "type":"OUTFILE", "name":{"subst":"cram_index_file"} },
     { "id":"cram_md5", "type":"OUTFILE", "name":{"subst":"cram_md5"} },
     { "id":"seqchksum_file", "type":"RAFILE", "name":{"subst":"seqchksum_file"} },
     { "id":"seqchksum_file_cram", "type":"RAFILE", "name":{"subst":"seqchksum_file_cram"}, "comment":"this file is a temporary fix for blocking problems at the cmp_seqchksum node" },
@@ -309,7 +315,8 @@
     { "id":"bmdmw_to_b2c", "from":"bmd_multiway:b2c", "to":"bam2cram" },
     { "id":"b2c_to_cram_tee", "from":"bam2cram", "to":"cram_tee" },
     { "id":"cram_tee_to_md5", "from":"cram_tee:md5", "to":"create_cram_md5" },
-    { "id":"cram_tee_to_crai", "from":"cram_tee:crai", "to":"cram_index" },
+    { "id":"cram_tee_to_crai", "from":"cram_tee:crai", "to":"cram_index:cram" },
+    { "id":"cidx_to_file", "from":"cram_index:idx", "to":"cram_index_file" },
     { "id":"cram_tee_to_bscs", "from":"cram_tee:seqchksum", "to":"cram_seqchksum" },
     { "id":"md5_to_postprocess", "from":"create_cram_md5", "to":"postprocess_md5" },
     { "id":"bmdmw_to_sts_F0x900", "from":"bmd_multiway:samtools_stats_F0x900", "to":"samtools_stats_F0x900" },


### PR DESCRIPTION
use "samtools index" instead of "cram_index" to create cram indexes
for bam and cram index creation, use "samtools index -o <index_file>" to explicitly indicate the index file