### PR TITLE
Stage2 init options

### DIFF
--- a/data/static_params/stage2_reanalysis/align_bwa_mem2.json
+++ b/data/static_params/stage2_reanalysis/align_bwa_mem2.json
@@ -1,0 +1,13 @@
+{
+  "assign": [
+    {
+      "alignment_method": "bwa_mem",
+      "bwa_executable": "bwa-mem2"
+    }
+  ],
+  "assign_local": {},
+  "ops": {
+    "splice": [],
+    "prune": []
+  }
+}

--- a/data/static_params/stage2_reanalysis/base_params_duplexseq_cram.json
+++ b/data/static_params/stage2_reanalysis/base_params_duplexseq_cram.json
@@ -16,7 +16,7 @@
       "s2_filter_files": "DUMMY",
       "spatial_filter_file": "DUMMY",
       "phix_reference_genome_fasta":"DUMMY",
-      "realignment_switch":1
+      "realignment_switch":0
     }
   ],
   "assign_local": {},

--- a/data/static_params/stage2_reanalysis/base_params_duplexseq_cram.json
+++ b/data/static_params/stage2_reanalysis/base_params_duplexseq_cram.json
@@ -1,0 +1,37 @@
+{
+  "assign": [
+    {
+      "spatial_filter_switch":"off",
+      "markdup_optical_distance_value": "100",
+      "s2_se_pe": "pe",
+      "samtools_executable": "samtools",
+      "s2_input_format": "cram",
+      "markdup_method": "duplexseq",
+      "s2_ppi_switch":"s2_ppi",
+      "pp_read2tags":"on",
+      "pp_import_method":"crammerge",
+      "fastq_s2_pi_fq1": "DUMMY",
+      "fastq_s2_pi_fq2": "DUMMY",
+      "fastq_s2_pi_RG_ID": "DUMMY",
+      "s2_filter_files": "DUMMY",
+      "spatial_filter_file": "DUMMY",
+      "phix_reference_genome_fasta":"DUMMY",
+      "realignment_switch":1
+    }
+  ],
+  "assign_local": {},
+  "ops": {
+    "splice": [
+      "aln_bam12auxmerge:-foptgt_000_fixmate:",
+      "foptgt_seqchksum_file:-scs_cmp_seqchksum:outputchk"
+    ],
+    "prune": [
+      "foptgt.*_bmd_multiway:calibration_pu-",
+      "foptgt_cram_tee:c2a-",
+      "foptgt.*samtools_stats_F0.*_target.*-",
+      "foptgt.*samtools_stats_F0.*00_bait.*-",
+      "aln_tee3_tee3:to_phix_aln-scs_cmp_seqchksum:outputchk",
+      "ssfqc_tee_ssfqc:subsample-"
+    ]
+  }
+}

--- a/data/static_params/stage2_reanalysis/base_params_duplexseq_fastq.json
+++ b/data/static_params/stage2_reanalysis/base_params_duplexseq_fastq.json
@@ -14,7 +14,7 @@
       "s2_filter_files": "DUMMY",
       "spatial_filter_file": "DUMMY",
       "phix_reference_genome_fasta":"DUMMY",
-      "realignment_switch":1
+      "realignment_switch":0
     }
   ],
   "assign_local": {},

--- a/data/static_params/stage2_reanalysis/base_params_duplexseq_fastq.json
+++ b/data/static_params/stage2_reanalysis/base_params_duplexseq_fastq.json
@@ -1,0 +1,35 @@
+{
+  "assign": [
+    {
+      "spatial_filter_switch":"off",
+      "markdup_optical_distance_value": "100",
+      "s2_se_pe": "pe",
+      "samtools_executable": "samtools",
+      "s2_input_format": "cram",
+      "markdup_method": "duplexseq",
+      "s2_ppi_switch":"s2_ppi",
+      "pp_read2tags":"on",
+      "pp_import_method":"fastq",
+      "incrams": "DUMMY",
+      "s2_filter_files": "DUMMY",
+      "spatial_filter_file": "DUMMY",
+      "phix_reference_genome_fasta":"DUMMY",
+      "realignment_switch":1
+    }
+  ],
+  "assign_local": {},
+  "ops": {
+    "splice": [
+      "aln_bam12auxmerge:-foptgt_000_fixmate:",
+      "foptgt_seqchksum_file:-scs_cmp_seqchksum:outputchk"
+    ],
+    "prune": [
+      "foptgt.*_bmd_multiway:calibration_pu-",
+      "foptgt_cram_tee:c2a-",
+      "foptgt.*samtools_stats_F0.*_target.*-",
+      "foptgt.*samtools_stats_F0.*00_bait.*-",
+      "aln_tee3_tee3:to_phix_aln-scs_cmp_seqchksum:outputchk",
+      "ssfqc_tee_ssfqc:subsample-"
+    ]
+  }
+}

--- a/data/vtlib/alignment_wtsi_stage2_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_template.json
@@ -95,24 +95,20 @@
 ],
 "nodes":[
 	{
-		"id":"crammerge",
-		"type":"EXEC",
-		"use_STDIN": false,
-		"use_STDOUT": true,
-		"cmd": [
-			"samtools",
-			"merge",
-			"-n",
-			"-O", "BAM",
-			"-l", "0",
-			{"select":"s2_input_format", "default":"cram", "select_range":[1], "cases":{
-				"cram":["--input-fmt-option", "no_ref=1"],
-				"bam":["--input-fmt", "bam"]
+		"id":"preprocess_inputs",
+		"type":"VTFILE",
+		"name":{"subst":"s2_preprocess_inputs_method", "required":true,
+			"ifnull":{
+				"select":"s2_ppi_switch", "default":"crammerge","select_range":[1],
+				"cases":{
+					"crammerge":"crammerge.json",
+					"s2_ppi":"stage2_preprocess_inputs.json"
+				}
 			}},
-			"-",
-			{"subst":"incrams"}
-		],
-		"description":"merge individual cram files from a sample into one bam file"
+                "subst_map":{"input_format":{"subst":"s2_input_format"}},
+		"comment":"inputs: NONE; outputs: _stdout_ (bam), subst_map_parameters:[input_format]",
+		"node_prefix":"ppi_",
+		"description":"subgraph to preprocess inputs. Default: merge individual cram files from a sample into one bam file"
 	},
 	{
 		"id":"spatial_filter",
@@ -264,7 +260,7 @@
 	}
 ],
 "edges":[
-	{ "id":"src_to_bc2", "from":"crammerge", "to":{"subst":"post_cm","required":true} },
+	{ "id":"src_to_bc2", "from":"preprocess_inputs", "to":{"subst":"post_cm","required":true} },
 	{"select":"spatial_filter_switch", "required":true, "select_range":[1], "default":"on", "allow_unspec_keys":true,
 	"cases":{
 		"on": [

--- a/data/vtlib/crammerge.json
+++ b/data/vtlib/crammerge.json
@@ -1,0 +1,37 @@
+{
+"version":"2.0",
+"description":"run bwa mem to to align input bam to supplied reference genome",
+"subgraph_io":{
+	"ports":{
+		"inputs":{
+		},
+		"outputs":{
+			"_stdout_":"crammerge"
+		}
+	}
+},
+"subst_params":[],
+"nodes":[
+	{
+		"id":"crammerge",
+		"type":"EXEC",
+		"use_STDIN": false,
+		"use_STDOUT": true,
+		"cmd": [
+			"samtools",
+			"merge",
+			"-n",
+			"-O", "BAM",
+			"-l", "0",
+			{"select":"input_format", "default":"cram", "select_range":[1], "cases":{
+				"cram":["--input-fmt-option", "no_ref=1"],
+				"bam":["--input-fmt", "bam"]
+			}},
+			"-",
+			{"subst":"incrams", "required":true}
+		],
+		"description":"merge individual cram files from a sample into one bam file"
+	}
+],
+"edges":[]
+}

--- a/data/vtlib/read2tags.json
+++ b/data/vtlib/read2tags.json
@@ -1,0 +1,54 @@
+{
+"version":"2.0",
+"description":"read2tags for NanoSeq processing, including preparatory collation and reset",
+"subgraph_io":{
+	"ports":{
+		"inputs":{"_stdin_":"collate"},
+		"outputs":{ "_stdout_":"read2tags" }
+		}
+},
+"nodes":[
+	{
+		"id":"collate",
+		"type": "EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd": [
+			{"subst":"samtools_executable", "required":true, "ifnull":"samtools"}, "collate",
+			"--threads", {"subst":"s2_r2t_coll_threads","required":true,"ifnull":2},
+			"-u",
+			"-O",
+			"-"
+		]
+	},
+	{
+		"id":"reset",
+		"type": "EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd": [
+			{"subst":"samtools_executable", "required":true, "ifnull":"samtools"}, "reset",
+			"--threads", {"subst":"s2_r2t_rs_threads","required":true,"ifnull":4},
+			"--output-fmt", "BAM,level=0"
+		]
+	},
+	{
+		"id":"read2tags",
+		"type": "EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd": [
+			{"subst":"bambi_executable", "required":true, "ifnull":"bambi"}, "read2tags",
+			"--tags", "rb,mb,br,rb,mb,br",
+			"--qtags", "rq,mq,bq,rq,mq,bq",
+			"--positions", "1:1:1:3,1:2:1:3,1:1:4:7,2:2:1:3,2:1:1:3,2:2:4:7",
+			"--compression-level", 0,
+			"--output-fmt", "bam"
+		]
+	}
+],
+"edges":[
+	{ "id":"collate_to_reset", "from":"collate","to":"reset" },
+	{ "id":"reset_to_read2tags", "from":"reset", "to":"read2tags" }
+]
+}

--- a/data/vtlib/stage2_preprocess_inputs.json
+++ b/data/vtlib/stage2_preprocess_inputs.json
@@ -1,0 +1,81 @@
+{
+"version":"2.0",
+"description":"alternate pre-processing method for stage2 inputs accepting FASTQ input (for e.g. Elembio NanoSeq)",
+"subgraph_io":{
+	"ports":{
+		"inputs":{},
+		"outputs":{ "_stdout_":
+			{"select":"pp_read2tags", "required":true, "default":"off",
+				"cases":{
+					"off": "import",
+					"on": "read2tags"
+				}
+			}
+		}
+	}
+},
+"nodes":[
+	{
+		"id":"import",
+		"type":"EXEC",
+		"use_STDIN": false,
+		"use_STDOUT": true,
+		"cmd": {
+			"select":"pp_import_method",
+			"required":true,
+			"select_range":[1],
+			"default":"crammerge",
+			"cases":{
+			"crammerge":
+			[
+				{"subst":"samtools_executable", "required":true, "ifnull":"samtools"}, "merge",
+				"-n",
+				"-O", "BAM",
+				"-l", "0",
+				{"select":"input_format", "default":"cram", "select_range":[1], "cases":{
+					"cram":["--input-fmt-option", "no_ref=1"],
+					"bam":["--input-fmt", "bam"]
+				}},
+				"-",
+				{"subst":"incrams", "required":true}
+			],
+			"fastq":
+			[
+				{"subst":"samtools_executable", "required":true, "ifnull":"samtools"}, "import",
+				"-R", {"subst":"fastq_s2_pi_RG_ID","required":true, "comment":"readgroup"},
+				"-1", {"subst":"fastq_s2_pi_fq1","required":true, "comment":"FASTQ read 1"},
+				"-2", {"subst":"fastq_s2_pi_fq2","required":true, "comment":"FASTQ read 2"},
+				{"select":"parse_casava_id", "default":"on", "select_range":[1], "cases":{ "on":["-i"], "off":[] }},
+				{"subst":"parse_import_tags_flag", "ifnull":["-T", {"subst":"parse_import_tags","required":true,"ifnull":"*"}]},
+				"-u",
+				"-O", "bam"
+			]
+			}
+		}
+	},
+	{
+		"id":"read2tags",
+		"type":{
+			"select":"pp_read2tags",
+			"required":true,
+			"select_range":[1],
+			"default":"off",
+			"cases":{
+				"on":"VTFILE",
+				"off":"INACTIVE"
+			}
+		},
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"name":"read2tags.json",
+		"node_prefix":"r2t_"
+	}
+],
+"edges":[
+	{"select":"pp_read2tags", "required":true, "default":"off", "cases":{
+		"off": [],
+		"on": [ { "id":"import_to_read2tags", "from":"import", "to":"read2tags" }]
+		}
+	}
+]
+}

--- a/data/vtlib/subsample.json
+++ b/data/vtlib/subsample.json
@@ -36,22 +36,15 @@
 	},
         {
                 "id":"subsample",
-                "type":"EXEC",
-		"subtype":"STRINGIFY",
-		"use_STDIN": true,
-		"use_STDOUT": true,
-		"cmd":[
-			"bash -c '",
-			{"subst_constructor":{"vals":["tmfs=\"", {"subst":"tag_metrics_files", "required":true}, "\""],"postproc":{"op":"concat","pad":""}}}, "; if [ ! -z \"${tmfs}\" ]; then for tag_metrics_file in ${tmfs}; do reads_count=`jq", {"subst":"jqkey", "ifnull":{"subst_constructor":{"vals":["'\"'\"'.reads_count.\"", {"subst":"s2_tag_index", "required":true}, "\"'\"'\"'"],"postproc":{"op":"concat","pad":""}}}}, "${tag_metrics_file}`; reads_count=`echo ${reads_count} | tr -cd [:digit:]`; reads_count_total=$((${reads_count_total}+${reads_count})); done; if [[ $reads_count_total -eq 0 ]]; then reads_count_total=1; fi; frac=`echo \"10000/${reads_count_total}\" | bc -l`; fi;",
-			"if [ ! -z $frac ]; then",
-				"samtools",
-				"view",
-				"-s", {"subst":"seed_frac", "required":true, "ifnull": {"subst_constructor":{"vals":[ {"subst":"subsample_seed", "ifnull":{"subst":"s2_id_run", "required":true}}, "${frac}" ],"postproc":{"op":"concat","pad":""}}}},
-				"-b",
-				"-",
-				";",
-			"else >&2 printf \"No tag metrics, no subsample\"; fi;'"
-		]
+		"type":"VTFILE",
+		"name":{"subst":"s2_subsample_method", "required":true,
+			"ifnull":{
+				"select":"s2_subsample_method_switch", "default":"tmf","select_range":[1],
+				"cases":{
+					"tmf":"subsample_tmf.json",
+					"spec_frac":"subsample_spec_frac.json"}
+			}},
+		"node_prefix":"ssm_"
         },
         {
                 "id":"bamtofastq_ss",

--- a/data/vtlib/subsample_spec_frac.json
+++ b/data/vtlib/subsample_spec_frac.json
@@ -1,0 +1,31 @@
+{
+"version":"2.0",
+"description":"produce 10k subsample fastq files",
+"subgraph_io":{
+	"ports":{
+		"inputs":{
+			"_stdin_":"subsample"
+		},
+		"outputs":{
+			"_stdout_":"subsample"
+		}
+	}
+},
+"subst_params":[],
+"nodes":[
+        {
+                "id":"subsample",
+                "type":"EXEC",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd":[
+			"samtools",
+			"view",
+			"-s", {"subst":"seed_frac", "required":true, "ifnull": {"subst_constructor":{"vals":[ {"subst":"subsample_seed", "ifnull":{"subst":"s2_id_run", "required":true}}, {"subst":"ss_frac", "required":true}],"postproc":{"op":"concat","pad":"."}}}},
+			"-b",
+			"-"
+		]
+        }
+],
+"edges":[]
+}

--- a/data/vtlib/subsample_tmf.json
+++ b/data/vtlib/subsample_tmf.json
@@ -1,0 +1,37 @@
+{
+"version":"2.0",
+"description":"produce 10k subsample fastq files",
+"subgraph_io":{
+	"ports":{
+		"inputs":{
+			"_stdin_":"subsample"
+		},
+		"outputs":{
+			"_stdout_":"subsample"
+		}
+	}
+},
+"subst_params":[],
+"nodes":[
+        {
+                "id":"subsample",
+                "type":"EXEC",
+		"subtype":"STRINGIFY",
+		"use_STDIN": true,
+		"use_STDOUT": true,
+		"cmd":[
+			"bash -c '",
+			{"subst_constructor":{"vals":["tmfs=\"", {"subst":"tag_metrics_files", "required":true}, "\""],"postproc":{"op":"concat","pad":""}}}, "; if [ ! -z \"${tmfs}\" ]; then for tag_metrics_file in ${tmfs}; do reads_count=`jq", {"subst":"jqkey", "ifnull":{"subst_constructor":{"vals":["'\"'\"'.reads_count.\"", {"subst":"s2_tag_index", "required":true}, "\"'\"'\"'"],"postproc":{"op":"concat","pad":""}}}}, "${tag_metrics_file}`; reads_count=`echo ${reads_count} | tr -cd [:digit:]`; reads_count_total=$((${reads_count_total}+${reads_count})); done; if [[ $reads_count_total -eq 0 ]]; then reads_count_total=1; fi; frac=`echo \"10000/${reads_count_total}\" | bc -l`; fi;",
+			"if [ ! -z $frac ]; then",
+				"samtools",
+				"view",
+				"-s", {"subst":"seed_frac", "required":true, "ifnull": {"subst_constructor":{"vals":[ {"subst":"subsample_seed", "ifnull":{"subst":"s2_id_run", "required":true}}, "${frac}" ],"postproc":{"op":"concat","pad":""}}}},
+				"-b",
+				"-",
+				";",
+			"else >&2 printf \"No tag metrics, no subsample\"; fi;'"
+		]
+        }
+],
+"edges":[]
+}


### PR DESCRIPTION
- allow choice of import formats (BAM/CRAM, FASTQ)
- add optional bambi read2tags processing
- vtfp 1) extend template preprocessing to subgraph_io sections (in subgraphs); 2) when pruning, only remove ports that do not appear in splice edges (aka replacement edges)
- allow specification of input processing for stage2 analysis
- add static parameter files for stand-alone reanalyses