### PR TITLE
readnames re-pair tweak

### DIFF
--- a/data/vtlib/bowtie2_alignment.json
+++ b/data/vtlib/bowtie2_alignment.json
@@ -64,7 +64,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-		"cmd":[ "perl", "-nale", "use strict; $,=qq(\\t); use File::Slurp; our($body,@lpg); if($body||=not m{^\\@}){if(@lpg){my$cl=read_file(q(/proc/self/cmdline));$cl=~s/\\x{000}/ /g; $cl=~s/\\t/ /g; print join qq[\\t], q(@PG),q(ID:perlfoo),q(PN:perl),q(DS:fixup paired read bits name suffixes),q(PP:).(shift@lpg),q(CL:).$cl} if($F[0]=~s{/([12])$}{}){ $F[1]= $1==1?$F[1]|0x41:$F[1]|0x81} print join qq(\\t),@F}else{@lpg=($1) if m{^\\@PG.*\\tID:([^\\t]+)}; print}" ],
+                "cmd":[ "perl", "-nale", "use strict; $,=qq(\\t); our($body,@lpg, $pgc); if($body||=not m{^\\@}){if(@lpg){my$cl=qx{cat /proc/self/cmdline | tr '\\0\\t' ' '}; print join qq[\\t], q(@PG),qq(ID:perlfoo_$pgc),q(PN:perl),q(DS:fixup paired read bits name suffixes),q(PP:).(shift@lpg),q(CL:).$cl} if($F[0]=~s{/([12])$}{}){ $F[1]= $1==1?$F[1]|0x41:$F[1]|0x81} print join qq(\\t),@F}else{@lpg=($1); $pgc++; if m{^\\@PG.*\\tID:([^\\t]+)}; print}" ],
 		"description":"remove /1 and /2 read suffixes, updating the flags to reflect read number"
 	},
         {

--- a/data/vtlib/bowtie2_alignment.json
+++ b/data/vtlib/bowtie2_alignment.json
@@ -64,7 +64,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-                "cmd":[ "perl", "-nale", "use strict; $,=qq(\\t); our($body,@lpg, $pgc); if($body||=not m{^\\@}){if(@lpg){my$cl=qx{cat /proc/self/cmdline | tr '\\0\\t' ' '}; print join qq[\\t], q(@PG),qq(ID:perlfoo_$pgc),q(PN:perl),q(DS:fixup paired read bits name suffixes),q(PP:).(shift@lpg),q(CL:).$cl} if($F[0]=~s{/([12])$}{}){ $F[1]= $1==1?$F[1]|0x41:$F[1]|0x81} print join qq(\\t),@F}else{if(m{^\\@PG.*\\tID:([^\\t]+)}) {@lpg=($1); $pgc++;}; print}" ],
+                "cmd":[ "perl", "-nale", "use strict; $,=qq(\\t); our($body,@lpg, $pgc); if($body||=not m{^\\@}){if(@lpg){my$cl=qx{cat /proc/$$/cmdline}; $cl=~s{[\\0\\t\\n\\r]}{ }g; print join qq[\\t], q(@PG),qq(ID:perlfoo_$pgc),q(PN:perl),q(DS:fixup paired read bits name suffixes),q(PP:).(shift@lpg),q(CL:).$cl} if($F[0]=~s{/([12])$}{}){ $F[1]= $1==1?$F[1]|0x41:$F[1]|0x81} print join qq(\\t),@F}else{if(m{^\\@PG.*\\tID:([^\\t]+)}) {@lpg=($1); $pgc++;}; print}" ],
 		"description":"remove /1 and /2 read suffixes, updating the flags to reflect read number"
 	},
         {

--- a/data/vtlib/bowtie2_alignment.json
+++ b/data/vtlib/bowtie2_alignment.json
@@ -64,7 +64,7 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": true,
-                "cmd":[ "perl", "-nale", "use strict; $,=qq(\\t); our($body,@lpg, $pgc); if($body||=not m{^\\@}){if(@lpg){my$cl=qx{cat /proc/self/cmdline | tr '\\0\\t' ' '}; print join qq[\\t], q(@PG),qq(ID:perlfoo_$pgc),q(PN:perl),q(DS:fixup paired read bits name suffixes),q(PP:).(shift@lpg),q(CL:).$cl} if($F[0]=~s{/([12])$}{}){ $F[1]= $1==1?$F[1]|0x41:$F[1]|0x81} print join qq(\\t),@F}else{@lpg=($1); $pgc++; if m{^\\@PG.*\\tID:([^\\t]+)}; print}" ],
+                "cmd":[ "perl", "-nale", "use strict; $,=qq(\\t); our($body,@lpg, $pgc); if($body||=not m{^\\@}){if(@lpg){my$cl=qx{cat /proc/self/cmdline | tr '\\0\\t' ' '}; print join qq[\\t], q(@PG),qq(ID:perlfoo_$pgc),q(PN:perl),q(DS:fixup paired read bits name suffixes),q(PP:).(shift@lpg),q(CL:).$cl} if($F[0]=~s{/([12])$}{}){ $F[1]= $1==1?$F[1]|0x41:$F[1]|0x81} print join qq(\\t),@F}else{if(m{^\\@PG.*\\tID:([^\\t]+)}) {@lpg=($1); $pgc++;}; print}" ],
 		"description":"remove /1 and /2 read suffixes, updating the flags to reflect read number"
 	},
         {


### PR DESCRIPTION
Update node that removes /1 or /2 suffixes from readnames and updates flags to show they are paired
   remove File::Slurp so it works with current container build
   add suffix to new PG line ID value to increase likelihood of uniqueness