### PR TITLE
Remove logic to find tool executable in current directory

### DIFF
--- a/bin/vtfp.pl
+++ b/bin/vtfp.pl
@@ -127,7 +127,7 @@ foreach my $node_with_cmd ( grep {$_->{'cmd'}} @{$flat_graph->{'nodes'}}) {
 	if($absolute_program_paths) {
 		my $cmd_ref = \$node_with_cmd->{'cmd'};
 		if(ref ${$cmd_ref} eq 'ARRAY') { $cmd_ref = \${${$cmd_ref}}[0]}
-		${$cmd_ref} =~ s/\A(\S+)/ abs_path( (-x $1 ? $1 : undef) || (which $1) || croak "cannot find program $1" )/e;
+		${$cmd_ref} =~ s/\A(\S+)/ abs_path( (which $1) || croak "cannot find program $1" )/e;
 	}
 }
 if($flat_graph->{'edges'}) {


### PR DESCRIPTION
Just rely on normal PATH logic of OS.

Removes bug of trying to use a directory as the tool executable if there was a directory with the same name as the tool in the current directory.